### PR TITLE
Fix/Remove all warnings caused by scene code.

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -151,6 +151,7 @@ struct KarateManInfoSubstruct {
 };
 
 struct KarateManInfo {
+    u8 unk0;
 	struct KarateManInfoSubstruct unk_substruct;
     s16 unk14;
     u8 unk16;
@@ -171,6 +172,7 @@ struct KarateManInfo {
 };
 
 struct RapMenInfo {
+    u8 unk0;
     u32 *unk4;
     s16 unk8;
     s16 unkA;
@@ -193,6 +195,7 @@ struct WizardsWaltzSparkle {
 };
 
 struct WizardsWaltzInfo {
+    u8 version;         // Value:   unk0
     struct ScaledEntity *wizardEntity;   // Entity:  unk4
     u8  wizardState;    // Value:   unk8 {0,1}
     u32 unkC;           // Value:   posUnk0C
@@ -201,7 +204,7 @@ struct WizardsWaltzInfo {
     u32 unk18;          // Value:   posUnk18
     u32 null1C;
     u32 null20;
-    struct ScaledEntity *shadowEntity;   // Entity:  unk24
+    struct ScaledEntity *shadowEntity; // Entity:  unk24
     u32 null28;
     u32 null2C;
     u32 null30;
@@ -210,7 +213,7 @@ struct WizardsWaltzInfo {
     u32 null3C;
     u32 null40;
     struct WizardsWaltzSparkle sparkle[10]; // Struct: unk44[10]
-    struct ScaledEntity *girlEntity;     // Entity:  unk184
+    struct ScaledEntity *girlEntity; // Entity:  unk184
     u8  girlState;      // Value:   unk188 {0,1,2}
     u32 null18C;
     u32 null190;
@@ -227,38 +230,39 @@ struct WizardsWaltzInfo {
 };
 
 struct RhythmTweezersTweezers {
-    u32 entity; // Entity: Tweezers
-    u8  unk4;   // Flag: Active
-    u8  unk5;   // State: Holding { 0 = False (Open); 1 = True (Full Hair); 2 = (Half Hair) }
-    s16 unk6;   // Value: 0x4ea - ((cyclePosition * 0x5d5) / cycleTarget)
+    u32 entity; // Entity:  Tweezers
+    u8  unk4;   // Flag:    Active
+    u8  unk5;   // State:   Holding { 0 = False (Open); 1 = True (Full Hair); 2 = (Half Hair) }
+    s16 unk6;   // Value:   0x4ea - ((cyclePosition * 0x5d5) / cycleTarget)
     u32 unk8;   // Counter: Cycle Position
-    u32 unkC;   // Value: Cycle Target
-    u8  unk10;  // Flag: Pulling (assigned but never used)
+    u32 unkC;   // Value:   Cycle Target
+    u8  unk10;  // Flag:    Pulling (assigned but never used)
 };
 
 struct RhythmTweezersFallingHair {
-    u32 entity; // Entity: Falling Hair
-    s32 unk4;   // Value: Vertical Velocity
+    u32 entity; // Entity:  Falling Hair
+    s32 unk4;   // Value:   Vertical Velocity
     u32 unk8;   // Counter: Vertical Position
-    s16 unkC;   // Value: Distance From Tweezers
-    u16 unkE;   // Value: Randomised Rotation Speed ( func_08001980(0x1f) - 0xf )
+    s16 unkC;   // Value:   Distance From Tweezers
+    u16 unkE;   // Value:   Randomised Rotation Speed ( func_08001980(0x1f) - 0xf )
 };
 
 struct RhythmTweezersVegetable {
-    s16 entity0; // Entity: Current Vegetable Face
-    s16 entity2; // Entity: Upcoming Vegetable Face
-    u8  unk4;    // State: Current Vegetable Type { 0 = Onion; 1 = Turnip; 2 = Potato }
-    u8  unk5;    // State: Upcoming Vegetable Type { 0 = Onion; 1 = Turnip; 2 = Potato }
-    u8  unk6;    // Flag: Screen Scrolling
-    u32 unk8;    // Counter: Screen Scroll Position
-    u32 unkC;    // Value: Screen Scroll Target
-    u8  unk10;   // Flag: Destination Vegetable BG Map { 0 = D_0600f800 (Right); -1 = D_0600f000 (Left) }
+    s16 entity0;    // Entity:  Current Vegetable Face
+    s16 entity2;    // Entity:  Upcoming Vegetable Face
+    u8  unk4;       // State:   Current Vegetable Type { 0 = Onion; 1 = Turnip; 2 = Potato }
+    u8  unk5;       // State:   Upcoming Vegetable Type { 0 = Onion; 1 = Turnip; 2 = Potato }
+    u8  unk6;       // Flag:    Screen Scrolling
+    u32 unk8;       // Counter: Screen Scroll Position
+    u32 unkC;       // Value:   Screen Scroll Target
+    u8  unk10;      // Flag:    Destination Vegetable BG Map { 0 = D_0600f800 (Right); -1 = D_0600f000 (Left) }
 };
 
 struct RhythmTweezersInfo {
+    u8 unk0;        // Value:   Version
     struct RhythmTweezersTweezers tweezers;
     u32 unk18;      // Counter: Hair Placement Cycle Position
-    u32 unk1C;      // Value: Hair Placement Cycle Spacing
+    u32 unk1C;      // Value:   Hair Placement Cycle Spacing
     u8  unk20;      // Counter: Next Available Falling Hair {0..4}
     struct RhythmTweezersFallingHair fallingHairs[5];
     struct RhythmTweezersVegetable vegetable;
@@ -266,15 +270,13 @@ struct RhythmTweezersInfo {
         u16 u16[2];     // Missed/Queued; Barely'd
         u32 u32;        // Combined (NOT Total)
     } unk88;
-    s16 unk8C;      // Entity: Tutorial Text (Unused)
-    u16 unk8E;      // Value: Global Horizontal Position (for vegetable faces and hair)
-    s16 unk90;      // Value: Mask Current Position
-    s16 unk92;      // Value: Mask Vertical Motion
+    s16 unk8C;      // Entity:  Tutorial Text (Unused)
+    u16 unk8E;      // Value:   Global Horizontal Position (for vegetable faces and hair)
+    s16 unk90;      // Value:   Mask Current Position
+    s16 unk92;      // Value:   Mask Vertical Motion
 };
 
 struct struct_030055d0 {
-    u8 unk0;
-    u8 pad01[3];
     union {
         struct KarateManInfo karateMan;
         struct RapMenInfo rapMen;

--- a/include/types.h
+++ b/include/types.h
@@ -230,7 +230,7 @@ struct WizardsWaltzInfo {
 };
 
 struct RhythmTweezersTweezers {
-    u32 entity; // Entity:  Tweezers
+    struct ScaledEntity *entity; // Entity:  Tweezers
     u8  unk4;   // Flag:    Active
     u8  unk5;   // State:   Holding { 0 = False (Open); 1 = True (Full Hair); 2 = (Half Hair) }
     s16 unk6;   // Value:   0x4ea - ((cyclePosition * 0x5d5) / cycleTarget)
@@ -240,7 +240,7 @@ struct RhythmTweezersTweezers {
 };
 
 struct RhythmTweezersFallingHair {
-    u32 entity; // Entity:  Falling Hair
+    struct ScaledEntity *entity; // Entity:  Falling Hair
     s32 unk4;   // Value:   Vertical Velocity
     u32 unk8;   // Counter: Vertical Position
     s16 unkC;   // Value:   Distance From Tweezers

--- a/src/code_08001360.h
+++ b/src/code_08001360.h
@@ -128,7 +128,7 @@ extern u8 func_08001fc4(u8 *);
 // extern ? func_08002e78(?);
 // extern ? func_08002eb0(?);
 // extern ? func_08002ecc(?);
-extern u32 func_08002ee0(u16, u32, u32);
+extern u32 func_08002ee0(u16, u32 *, u32);
 // extern ? func_08002f04(?);
 // extern ? func_08002f40(?);
 // extern ? func_08002f48(?);

--- a/src/code_0800b778.c
+++ b/src/code_0800b778.c
@@ -8,8 +8,7 @@ asm(".include \"include/gba.inc\"");//Temporary
 
 static s32 D_03001310[2]; // unknown type
 
-
-extern u32 func_0804d160(s32, u32 *, s8, s16, s16, u16, s8, s8, u16);
+extern u32 func_0804d160(s32, u32 *, s8, s16, s16, u16, s8, s8, u16); // Non-Scalable/Non-Rotatable Entity
 
 #include "asm/code_0800b778/asm_0800b778.s"
 

--- a/src/scenes.h
+++ b/src/scenes.h
@@ -693,9 +693,9 @@ extern void func_0802ee24(void);        // [func_0802ee24] MAIN - Loop
 extern void func_0802ee40_stub(void);   // [func_0802ee40] MAIN - Unload (STUB)
 extern void func_0802ee44(void);        // [func_0802ee44] ENGINE Func_01 - Reset Hair Position Cycle
 extern void func_0802ee6c(void);        // [func_0802ee6c] SUB - Update Hair Position Cycle
-// extern void func_0802ee7c(u32, struct struct_080179f4_sub1 *, u32, u32); // [func_0802ee7c] CUE Spawn - Short Hair, Long Hair
+extern void func_0802ee7c(u32, struct struct_080179f4_sub1 *, u32, u32);    // [func_0802ee7c] CUE Spawn - Short Hair, Long Hair
 extern u32  func_0802ef54(u32, struct struct_080179f4_sub1 *, u32, u32);    // [func_0802ef54] CUE Behaviour - Short Hair
-// extern u32  func_0802ef68(u32, struct struct_080179f4_sub1 *, u32, u32); // [func_0802ef68] CUE Behaviour - Long Hair
+extern u32  func_0802ef68(u32, struct struct_080179f4_sub1 *, u32, u32);    // [func_0802ef68] CUE Behaviour - Long Hair
 extern void func_0802f164(u32, struct struct_080179f4_sub1 *, u32, u32);    // [func_0802f164] CUE Despawn - Short Hair, Long Hair
 extern void func_0802f170(u32, struct struct_080179f4_sub1 *, u32, u32);    // [func_0802f170] CUE Hit - Short Hair
 extern void func_0802f21c(u32, struct struct_080179f4_sub1 *, u32, u32);    // [func_0802f21c] CUE Hit, CUE Barely - Long Hair
@@ -1576,25 +1576,25 @@ extern void func_08039df8(void);
 
 // Wizard's Waltz
 
-extern void func_080449a4(void);                                            // [func_080449a4]
-extern void func_080449b4(void);                                            // [func_080449b4]
-extern void func_080449e4(void);                                            // [func_080449e4]
-extern void waltz_main_load(u32);                                           // [func_08044a10]
-extern void waltz_beatscript_set_rotation(u32);                             // [func_08044b80]
-extern void waltz_update_position(u32, s32, s32, u32);                      // [func_08044ba8]
-extern void waltz_main_loop(void);                                          // [func_08044c04]
-extern void waltz_beatscript_set_tutorial(u32);                             // [func_08044e60]
-extern void waltz_main_unload(void);                                        // [func_08044e74] (STUB)
-// extern ? func_08044e78(?);                                               // [func_08044e78]
-extern u32  waltz_cue_unknown(u32, u32, u32);                               // [func_08044f94]
-extern void waltz_cue_despawn(u32, u32 *);                                  // [func_08044fc0]
-extern void waltz_cue_hit(u32, struct struct_080179f4_sub *);               // [func_08044fcc]
-extern void waltz_cue_barely(u32, struct struct_080179f4_sub *);            // [func_0804503c]
-extern void waltz_cue_miss(u32, struct struct_080179f4_sub *);              // [func_080450d0]
-extern void waltz_main_unknown(void);                                       // [func_080450dc] (STUB)
-extern void func_080450e0(void);                                            // [func_080450e0] (STUB)
-extern void func_080450e4(void);                                            // [func_080450e4] (STUB)
-extern void func_080450e8(u32 arg0);                                        // [func_080450e8]
+extern void func_080449a4(void);                // [func_080449a4] GFX_LOAD Func_02
+extern void func_080449b4(void);                // [func_080449b4] GFX_LOAD Func_01
+extern void func_080449e4(void);                // [func_080449e4] GFX_LOAD Func_00
+extern void func_08044a10(u32);                 // [func_08044a10] MAIN - Load
+extern void func_08044b80(u32);                 // [func_08044b80] ENGINE Func_00 - Set Rotation Interval
+extern void func_08044ba8(struct ScaledEntity *, s32, s32, u32);    // [func_08044ba8] SUB - Update Entity Position
+extern void func_08044c04(void);                // [func_08044c04] MAIN - Loop
+extern void func_08044e60(u32);                 // [func_08044e60] ENGINE Func_01 - Set Tutorial Flag
+extern void func_08044e74_stub(void);           // [func_08044e74] MAIN - Unload (STUB)
+extern void func_08044e78(u32, struct struct_080179f4_sub *, u32);  // [func_08044e78] CUE Spawn
+extern u32  func_08044f94(u32, struct struct_080179f4_sub *, u32);  // [func_08044f94] CUE Behaviour
+extern void func_08044fc0(u32, struct struct_080179f4_sub *, u32);  // [func_08044fc0] CUE Despawn
+extern void func_08044fcc(u32, struct struct_080179f4_sub *, u32);  // [func_08044fcc] CUE Hit
+extern void func_0804503c(u32, struct struct_080179f4_sub *, u32);  // [func_0804503c] CUE Barely
+extern void func_080450d0(u32, struct struct_080179f4_sub *, u32);  // [func_080450d0] CUE Miss
+extern void func_080450dc_stub(void);           // [func_080450dc] MAIN - Input Event (STUB)
+extern void func_080450e0_stub(void);           // [func_080450e0] GRAPHICAL Func_00 - Unknown (STUB, Unused)
+extern void func_080450e4_stub(void);           // [func_080450e4] GRAPHICAL Func_01 - Unknown (STUB, Unused)
+extern void func_080450e8(u32);                 // [func_080450e8] GRAPHICAL Func_02 - Unknown (Unused?)
 
 // Sneaky Spirits prologue
 

--- a/src/scenes/karate_man.inc.c
+++ b/src/scenes/karate_man.inc.c
@@ -160,7 +160,7 @@ void func_080215cc(void) {
 }
 
 void func_0802160c(struct struct_080179f4_sub *arg0) {
-    u32 *temp1;
+    struct struct_080179f4_sub *temp1;
     struct struct_030055d0 *temp2;
 
     func_08018124(&temp1, &temp2);

--- a/src/scenes/karate_man.inc.c
+++ b/src/scenes/karate_man.inc.c
@@ -9,9 +9,9 @@
 extern s16 D_03004afc;
 
 // !TODO
-extern void func_0804d770(u32, u32, u16);
-extern void func_0804cebc(u32, s16, s8);
-extern u32 func_0804d160(u32, u32 *, s8, u32, u32, u32, u32, u32, u32);
+extern void func_0804cebc(s32, s16, s8);
+extern u32  func_0804d160(s32, u32 *, s8, s16, s16, u16, s8, s8, u16);
+extern void func_0804d770(s32, s16, u16);
 
 extern u32 D_088acc2c[];
 extern u32 D_088acc94[];

--- a/src/scenes/karate_man.inc.c
+++ b/src/scenes/karate_man.inc.c
@@ -1,6 +1,7 @@
+#include "src/code_08001360.h"
 #include "src/code_08007468.h"
 #include "src/code_0800b3c8.h"
-#include "src/code_08001360.h"
+#include "src/code_0800b778.h"
 
 // For readability. !TODO - CHANGE/REMOVE
 #define gKarateManInfo D_030055d0->gameInfo.karateMan

--- a/src/scenes/karate_man.inc.c
+++ b/src/scenes/karate_man.inc.c
@@ -2,6 +2,9 @@
 #include "src/code_0800b3c8.h"
 #include "src/code_08001360.h"
 
+// For readability. !TODO - CHANGE/REMOVE
+#define gKarateManInfo D_030055d0->gameInfo.karateMan
+
 extern s16 D_03004afc;
 
 // !TODO
@@ -37,7 +40,7 @@ void func_080211a4(void) {
     u32 temp;
 
     func_0800c604(0);
-    temp = func_08002ee0(func_0800c3b8(), D_089df1ac[D_030055d0->unk0], 0x2000);
+    temp = func_08002ee0(func_0800c3b8(), D_089df1ac[gKarateManInfo.unk0], 0x2000);
     func_08005d38(temp, func_08021190, 0);
 }
 
@@ -54,7 +57,7 @@ void func_080211e4(void) {
 void func_0802139c(u32 arg0, u32 arg1) {
     func_08003eb8(D_089df1bc[arg0], D_06008000);
     func_0800e030(0);
-    D_030055d0->gameInfo.karateMan.unk32 = func_0800c3a4(arg1 + 1);
+    gKarateManInfo.unk32 = func_0800c3a4(arg1 + 1);
 }
 
 void func_080213d4(u32 arg0) {
@@ -63,37 +66,37 @@ void func_080213d4(u32 arg0) {
 
 
 void func_080213e4(void) {
-   if (D_030055d0->gameInfo.karateMan.unk32) {
-       D_030055d0->gameInfo.karateMan.unk32--;
-       if (!D_030055d0->gameInfo.karateMan.unk32) {
+   if (gKarateManInfo.unk32) {
+       gKarateManInfo.unk32--;
+       if (!gKarateManInfo.unk32) {
            func_0800e044(0);
        }
    }
 }
 
 void func_08021408(void) {
-    if (D_030055d0->unk0 == 0) {
-        D_030055d0->gameInfo.karateMan.unk34 = 1;
+    if (gKarateManInfo.unk0 == 0) {
+        gKarateManInfo.unk34 = 1;
     }
 }
 
 void func_08021424(void) {
-    if (D_030055d0->unk0 == 2) {
-        D_030055d0->gameInfo.karateMan.unk35 = 1;
+    if (gKarateManInfo.unk0 == 2) {
+        gKarateManInfo.unk35 = 1;
     }
 }
 
 void func_08021440(u32 arg0) {
-	func_0800aa4c(D_030055d0->gameInfo.karateMan.unk24, arg0);
+	func_0800aa4c(gKarateManInfo.unk24, arg0);
 
 }
 
 void func_08021458(void) {
-    func_0804cebc(D_03005380, D_030055d0->gameInfo.karateMan.unk28, 0);
-    func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk28, 1);
+    func_0804cebc(D_03005380, gKarateManInfo.unk28, 0);
+    func_0804d770(D_03005380, gKarateManInfo.unk28, 1);
     func_08017338(0, 0);
     func_0800bd04(1);
-    D_030055d0->gameInfo.karateMan.unk2A = 1;
+    gKarateManInfo.unk2A = 1;
 }
 
 void func_080214a0(u32 arg0) {
@@ -108,17 +111,17 @@ void func_080214a0(u32 arg0) {
 }
 
 void func_080214d4(u32 arg0) {
-    D_030055d0->gameInfo.karateMan.unk30 = arg0;
+    gKarateManInfo.unk30 = arg0;
     if (arg0) {
-        func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk2E, 1);
-        func_0804cebc(D_03005380, D_030055d0->gameInfo.karateMan.unk2E, arg0);
+        func_0804d770(D_03005380, gKarateManInfo.unk2E, 1);
+        func_0804cebc(D_03005380, gKarateManInfo.unk2E, arg0);
     } else {
-        func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk2E, 0);
+        func_0804d770(D_03005380, gKarateManInfo.unk2E, 0);
     }
 }
 
 void func_08021524(void) {
-    if (D_030055d0->gameInfo.karateMan.unk30) {
+    if (gKarateManInfo.unk30) {
         func_0800bc40();
         return;
     }
@@ -127,31 +130,31 @@ void func_08021524(void) {
 
 
 void func_08021544(u8 arg0) {
-	D_030055d0->gameInfo.karateMan.unk36 = arg0;
+	gKarateManInfo.unk36 = arg0;
 }
 
 void func_08021554(void) {
-    if (D_030055d0->gameInfo.karateMan.unk2A) {
+    if (gKarateManInfo.unk2A) {
         if (D_03004afc & 1) {
-            func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk28, 0);
+            func_0804d770(D_03005380, gKarateManInfo.unk28, 0);
             func_08017338(1, 0);
             func_0800bd04(0);
-            D_030055d0->gameInfo.karateMan.unk2A = 0;
+            gKarateManInfo.unk2A = 0;
         }
     }
-    func_08021e58(&D_030055d0->gameInfo.karateMan.unk_substruct);
-    if (D_030055d0->unk0) {
-        if (D_030055d0->unk0 == 1) {
+    func_08021e58(&gKarateManInfo.unk_substruct);
+    if (gKarateManInfo.unk0) {
+        if (gKarateManInfo.unk0 == 1) {
             func_080213e4();
         }
     }
-    func_0800a914(D_030055d0->gameInfo.karateMan.unk24);
+    func_0800a914(gKarateManInfo.unk24);
 }
 
 void func_080215cc(void) {
-    func_08021e40(&D_030055d0->gameInfo.karateMan.unk_substruct);
-    func_0804d504(D_03005380, D_030055d0->gameInfo.karateMan.unk20);
-    func_0804d504(D_03005380, D_030055d0->gameInfo.karateMan.unk14);
+    func_08021e40(&gKarateManInfo.unk_substruct);
+    func_0804d504(D_03005380, gKarateManInfo.unk20);
+    func_0804d504(D_03005380, gKarateManInfo.unk14);
     func_0800e044(0);
     func_0800e044(1);
 }
@@ -198,24 +201,24 @@ void func_08021974(u32 arg0, struct struct_080179f4_sub *arg1) {
 void func_080219a8(void) {
     u32 temp;
 
-    D_030055d0->gameInfo.karateMan.unk34 = 0;
-    func_0804d8c4(D_03005380, D_030055d0->gameInfo.karateMan.unk_substruct.unk8, 1);
+    gKarateManInfo.unk34 = 0;
+    func_0804d8c4(D_03005380, gKarateManInfo.unk_substruct.unk8, 1);
     func_0800e030(0);
     func_0800e044(1);
-    func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk14, 0);
-    D_030055d0->unk0 = 2;
+    func_0804d770(D_03005380, gKarateManInfo.unk14, 0);
+    gKarateManInfo.unk0 = 2;
     func_0800c128(0);
     temp = 0x100;
     func_0800c138(temp, func_0800c3a4(0x60));
 }
 
 void func_08021a0c(void) {
-    D_030055d0->gameInfo.karateMan.unk35 = 0;
-    func_0804d8c4(D_03005380, D_030055d0->gameInfo.karateMan.unk_substruct.unk8, 0);
+    gKarateManInfo.unk35 = 0;
+    func_0804d8c4(D_03005380, gKarateManInfo.unk_substruct.unk8, 0);
     func_0800e044(0);
     func_0800e030(1);
-    func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk14, 1);
-    D_030055d0->unk0 = 0;
+    func_0804d770(D_03005380, gKarateManInfo.unk14, 1);
+    gKarateManInfo.unk0 = 0;
     func_080221cc();
     func_080173c4(0);
 }
@@ -226,9 +229,9 @@ void func_08021d38(u32 arg0, struct struct_030055d0_sub *arg1) {
     u32 temp;
     struct KarateManInfoSubstruct *temp1;
 
-    temp1 = &D_030055d0->gameInfo.karateMan.unk_substruct;
+    temp1 = &gKarateManInfo.unk_substruct;
     temp = 0;
-    if (D_030055d0->unk0 == 1) {
+    if (gKarateManInfo.unk0 == 1) {
         temp = 1;
     }
     arg1->unk0 = 0 | 1;
@@ -253,7 +256,7 @@ void func_08021dcc(void) {
 void func_08021dd8(struct KarateManInfoSubstruct *arg0) {
     arg0->unk4 = 0;
     arg0->unk8 = func_0804d160(D_03005380, D_088acc2c, 0, 0x50, 0x58, 0x4800, 1, 0, 0);
-    if (D_030055d0->unk0 == 2) {
+    if (gKarateManInfo.unk0 == 2) {
         func_0804d8c4(D_03005380, arg0->unk8, 1);
     }
     arg0->unkA = 0;
@@ -274,10 +277,10 @@ void func_08021e58(struct KarateManInfoSubstruct *arg0) {
 }
 
 void func_08021e88(void) {
-    struct KarateManInfoSubstruct *temp = &D_030055d0->gameInfo.karateMan.unk_substruct;
+    struct KarateManInfoSubstruct *temp = &gKarateManInfo.unk_substruct;
 
     temp->unk4 = 0 | 1;
-    if (D_030055d0->gameInfo.karateMan.unk16 < 3) {
+    if (gKarateManInfo.unk16 < 3) {
         func_0804d8f8(D_03005380, temp->unk8, D_088acd54, 0, 1, 0x7f, 0);
     } else {
         func_0804d8f8(D_03005380, temp->unk8, D_088acc94, 0, 1, 0x7f, 0);
@@ -288,46 +291,46 @@ void func_08021e88(void) {
 #include "asm/scenes/karate_man/asm_08021f04.s"
 
 void func_08022010(u32 arg0) {
-    func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk20, arg0 != 0);
+    func_0804d770(D_03005380, gKarateManInfo.unk20, arg0 != 0);
     if (arg0) {
-        func_0804cebc(D_03005380, D_030055d0->gameInfo.karateMan.unk20, arg0 - 1);
+        func_0804cebc(D_03005380, gKarateManInfo.unk20, arg0 - 1);
     }
 }
 
 void func_08022050(void) {
     u32 temp;
 
-    D_030055d0->gameInfo.karateMan.unk16 = 0;
-    temp = func_0804d160(D_03005380, D_088acd1c, D_030055d0->gameInfo.karateMan.unk16, 0x24, 0x10, 0x47f6, 0, 0, 0);
-    D_030055d0->gameInfo.karateMan.unk14 = temp;
-    D_030055d0->gameInfo.karateMan.unk17 = 1;
-    if (D_030055d0->unk0 == 2) {
-        func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk14, 0);
-        D_030055d0->gameInfo.karateMan.unk17 = 0;
+    gKarateManInfo.unk16 = 0;
+    temp = func_0804d160(D_03005380, D_088acd1c, gKarateManInfo.unk16, 0x24, 0x10, 0x47f6, 0, 0, 0);
+    gKarateManInfo.unk14 = temp;
+    gKarateManInfo.unk17 = 1;
+    if (gKarateManInfo.unk0 == 2) {
+        func_0804d770(D_03005380, gKarateManInfo.unk14, 0);
+        gKarateManInfo.unk17 = 0;
     }
-    D_030055d0->gameInfo.karateMan.unk18 = 0;
-    D_030055d0->gameInfo.karateMan.unk1C = D_089df37c;
+    gKarateManInfo.unk18 = 0;
+    gKarateManInfo.unk1C = D_089df37c;
 }
 
 void func_080220c4(void) {
-    if (D_030055d0->gameInfo.karateMan.unk16 > 2) {
+    if (gKarateManInfo.unk16 > 2) {
         func_08002634(&s_f_boxing_score_reset_seqData);
     }
-    D_030055d0->gameInfo.karateMan.unk16 = 0;
-    func_0804cebc(D_03005380, D_030055d0->gameInfo.karateMan.unk14, D_030055d0->gameInfo.karateMan.unk16);
-    D_030055d0->gameInfo.karateMan.unk18 = 0;
-    D_030055d0->gameInfo.karateMan.unk1C = D_089df37c;
+    gKarateManInfo.unk16 = 0;
+    func_0804cebc(D_03005380, gKarateManInfo.unk14, gKarateManInfo.unk16);
+    gKarateManInfo.unk18 = 0;
+    gKarateManInfo.unk1C = D_089df37c;
     func_080221cc();
 }
 
 void func_08022114(void) {
-    if (D_030055d0->gameInfo.karateMan.unk17) {
-        if (D_030055d0->gameInfo.karateMan.unk16 <= 4) {
-            D_030055d0->gameInfo.karateMan.unk16++;
-            func_0804cebc(D_03005380, D_030055d0->gameInfo.karateMan.unk14, D_030055d0->gameInfo.karateMan.unk16);
-            if (D_030055d0->gameInfo.karateMan.unk16 == 3) {
-                D_030055d0->gameInfo.karateMan.unk18 = 0;
-                D_030055d0->gameInfo.karateMan.unk1C = D_089df37e;
+    if (gKarateManInfo.unk17) {
+        if (gKarateManInfo.unk16 <= 4) {
+            gKarateManInfo.unk16++;
+            func_0804cebc(D_03005380, gKarateManInfo.unk14, gKarateManInfo.unk16);
+            if (gKarateManInfo.unk16 == 3) {
+                gKarateManInfo.unk18 = 0;
+                gKarateManInfo.unk1C = D_089df37e;
                 func_080221cc();
                 func_08002634(&s_f_boxing_score_up_seqData);
             }
@@ -336,13 +339,13 @@ void func_08022114(void) {
 }
 
 void func_08022170(void) {
-    if (D_030055d0->gameInfo.karateMan.unk17) {
-        if (D_030055d0->gameInfo.karateMan.unk16) {
-            D_030055d0->gameInfo.karateMan.unk16--;
-            func_0804cebc(D_03005380, D_030055d0->gameInfo.karateMan.unk14, D_030055d0->gameInfo.karateMan.unk16);
-            if (D_030055d0->gameInfo.karateMan.unk16 == 2) {
-                D_030055d0->gameInfo.karateMan.unk18 = 0;
-                D_030055d0->gameInfo.karateMan.unk1C = D_089df37c;
+    if (gKarateManInfo.unk17) {
+        if (gKarateManInfo.unk16) {
+            gKarateManInfo.unk16--;
+            func_0804cebc(D_03005380, gKarateManInfo.unk14, gKarateManInfo.unk16);
+            if (gKarateManInfo.unk16 == 2) {
+                gKarateManInfo.unk18 = 0;
+                gKarateManInfo.unk1C = D_089df37c;
                 func_080221cc();
                 func_08002634(&s_f_boxing_score_down_seqData);
             }
@@ -353,6 +356,6 @@ void func_08022170(void) {
 #include "asm/scenes/karate_man/asm_080221cc.s"
 
 void func_0802221c(u32 arg0) {
-    D_030055d0->gameInfo.karateMan.unk17 = arg0;
-    func_0804d770(D_03005380, D_030055d0->gameInfo.karateMan.unk14, arg0);
+    gKarateManInfo.unk17 = arg0;
+    func_0804d770(D_03005380, gKarateManInfo.unk14, arg0);
 }

--- a/src/scenes/karate_man.inc.c
+++ b/src/scenes/karate_man.inc.c
@@ -17,8 +17,8 @@ extern u32 D_088acc94[];
 extern u32 D_088acd1c[]; 
 extern u32 D_088acd54[]; 
 extern u32 D_088acc94[];
-extern u32 D_089df064;
-extern u32 D_089df1ac[];
+extern u32 D_089df064;      // GFX-related Null
+extern u32 *D_089df1ac[];   // GFX Struct Index
 extern u32 D_089df1bc[];
 extern u32 D_089df37c[];
 extern u32 D_089df37e[];

--- a/src/scenes/rap_men.inc.c
+++ b/src/scenes/rap_men.inc.c
@@ -1,5 +1,6 @@
-#include "src/code_0800b3c8.h"
 #include "src/code_08001360.h"
+#include "src/code_08007468.h"
+#include "src/code_0800b778.h"
 
 #define gRapMenInfo D_030055d0->gameInfo.rapMen
 

--- a/src/scenes/rap_men.inc.c
+++ b/src/scenes/rap_men.inc.c
@@ -5,9 +5,9 @@
 
 extern char *D_0805a8b0;
 
-extern u32 *D_089e63f8[];
-extern u32 D_089e6424;    // GFX-related Null
-extern u32 *D_089e6518[]; // GFX Struct Index
+extern u32 **D_089e63f8[];  // Animation Index (index of pairs of animation pointers; 0 = Rap Men; 1 = Rap Women)
+extern u32 D_089e6424;      // GFX-related Null
+extern u32 *D_089e6518[];   // GFX Struct Index
 extern u8 D_089e6520;
 extern u8 D_089e6525;
 

--- a/src/scenes/rap_men.inc.c
+++ b/src/scenes/rap_men.inc.c
@@ -1,6 +1,8 @@
 #include "src/code_0800b3c8.h"
 #include "src/code_08001360.h"
 
+#define gRapMenInfo D_030055d0->gameInfo.rapMen
+
 extern char *D_0805a8b0;
 
 extern u32 *D_089e63f8[];
@@ -24,7 +26,7 @@ extern u32 func_0804d160(u32, u32 *, s8, u32, u32, u32, u32, u32, u32);
 
 
 u32 *func_080398b4(u32 arg0) {
-    return D_089e63f8[arg0][D_030055d0->unk0];
+    return D_089e63f8[arg0][gRapMenInfo.unk0];
 }
 
 void func_080398d4(void) {
@@ -36,7 +38,7 @@ void func_080398e4(void) {
 	u32 temp;
 
 	func_0800c604(0);
-	temp = func_08002ee0(func_0800c3b8(), D_089e6518[D_030055d0->unk0], 0x2000);
+	temp = func_08002ee0(func_0800c3b8(), D_089e6518[gRapMenInfo.unk0], 0x2000);
 	func_08005d38(temp, func_080398d4, 0);
 }
 
@@ -51,19 +53,19 @@ void func_08039924(void) {
 void func_08039950(u32 arg0) {
     u32 *temp;
 
-    D_030055d0->unk0 = arg0;
+    gRapMenInfo.unk0 = arg0;
     func_08039924();
     func_0800e0ec();
     func_0800e0a0(1, 1, 0, 0, 0, 29, 1);
     temp = func_0800c660(0x340, 2);
-    D_030055d0->gameInfo.rapMen.unk4 = temp;
-    D_030055d0->gameInfo.rapMen.unkC = func_0804d160(D_03005380, func_08004c0c(temp, &D_0805a8b0, 1, 14), 0, 0x78, 0x94, 0, 0, 0, 0);
-    D_030055d0->gameInfo.rapMen.unk8 = func_0804d160(D_03005380, func_080398b4(10), 0, 0x46, 0x82, 0x4800, 1, 0x7f, 0);
-    D_030055d0->gameInfo.rapMen.unkA = func_0804d160(D_03005380, func_080398b4(9), 0, 0xa0, 0x82, 0x4800, 1, 0x7f, 0);
-    D_030055d0->gameInfo.rapMen.unkE = 0;
-    D_030055d0->gameInfo.rapMen.unk10 = 0;
-    D_030055d0->gameInfo.rapMen.unk12 = 0;
-    D_030055d0->gameInfo.rapMen.unk14 = 0;
+    gRapMenInfo.unk4 = temp;
+    gRapMenInfo.unkC = func_0804d160(D_03005380, func_08004c0c(temp, &D_0805a8b0, 1, 14), 0, 0x78, 0x94, 0, 0, 0, 0);
+    gRapMenInfo.unk8 = func_0804d160(D_03005380, func_080398b4(10), 0, 0x46, 0x82, 0x4800, 1, 0x7f, 0);
+    gRapMenInfo.unkA = func_0804d160(D_03005380, func_080398b4(9), 0, 0xa0, 0x82, 0x4800, 1, 0x7f, 0);
+    gRapMenInfo.unkE = 0;
+    gRapMenInfo.unk10 = 0;
+    gRapMenInfo.unk12 = 0;
+    gRapMenInfo.unk14 = 0;
     func_08017338(1, 0); 
 }
 
@@ -72,23 +74,23 @@ void func_08039a40(void) {
 }
 
 void func_08039a44(u32 arg0) {
-    func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unk8, func_080398b4((&D_089e6520)[arg0]), 0, 1, 0x7f, 0);
-    D_030055d0->gameInfo.rapMen.unkE = func_0800c3a4((&D_089e6525)[arg0]);
+    func_0804d8f8(D_03005380, gRapMenInfo.unk8, func_080398b4((&D_089e6520)[arg0]), 0, 1, 0x7f, 0);
+    gRapMenInfo.unkE = func_0800c3a4((&D_089e6525)[arg0]);
 }
 
 void func_08039a98(u32 arg0) {
-    D_030055d0->gameInfo.rapMen.unk14 = arg0;
+    gRapMenInfo.unk14 = arg0;
 }
 
 void func_08039aa4(void) {
-    if (D_030055d0->gameInfo.rapMen.unkE) {
-        D_030055d0->gameInfo.rapMen.unkE--;
+    if (gRapMenInfo.unkE) {
+        gRapMenInfo.unkE--;
     }
-    if (D_030055d0->gameInfo.rapMen.unk10) {
-        D_030055d0->gameInfo.rapMen.unk10--;
+    if (gRapMenInfo.unk10) {
+        gRapMenInfo.unk10--;
     }
-    if (D_030055d0->gameInfo.rapMen.unk12) {
-        D_030055d0->gameInfo.rapMen.unk12--;
+    if (gRapMenInfo.unk12) {
+        gRapMenInfo.unk12--;
     }
 }
 
@@ -97,9 +99,9 @@ void func_08039ad4(void) {
 }
 
 void func_08039ad8(u32 arg0, struct struct_080179f4_sub *arg1, u32 arg2) {
-    func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unkA, func_080398b4(3), 0, 1, 0x7f, 0);
-    D_030055d0->gameInfo.rapMen.unk10 = func_0800c3a4(0x24);
-    D_030055d0->gameInfo.rapMen.unk12 = func_0800c3a4(0x24);
+    func_0804d8f8(D_03005380, gRapMenInfo.unkA, func_080398b4(3), 0, 1, 0x7f, 0);
+    gRapMenInfo.unk10 = func_0800c3a4(0x24);
+    gRapMenInfo.unk12 = func_0800c3a4(0x24);
     arg1->unk0 = arg2;
 }
 
@@ -116,44 +118,44 @@ void func_08039b48(void) {
 }
 
 void func_08039b4c(u32 arg0, struct struct_080179f4_sub *arg1) {
-    func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unkA, func_080398b4(2), 0, 1, 0x7f, 0);
-    D_030055d0->gameInfo.rapMen.unk10 = func_0800c3a4(0x24);
+    func_0804d8f8(D_03005380, gRapMenInfo.unkA, func_080398b4(2), 0, 1, 0x7f, 0);
+    gRapMenInfo.unk10 = func_0800c3a4(0x24);
     func_0804d160(D_03005380, func_080398b4(7), 0, 0xa0, 0x82, 0x47f6, 1, 0, 3);
     func_08039a44(3);
-    func_08002634(D_089e652c[D_030055d0->unk0][arg1->unk0]);
+    func_08002634(D_089e652c[gRapMenInfo.unk0][arg1->unk0]);
     func_08002634(&s_SD1_seqData);
     func_08002634(&s_CC4_seqData);
 }
 
 void func_08039c00(void) {
-    func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unkA, func_080398b4(1), 0, 1, 0x7f, 0);
-    D_030055d0->gameInfo.rapMen.unk10 = func_0800c3a4(0x24);
-    func_08002634(D_089e652c[D_030055d0->unk0][0]);
+    func_0804d8f8(D_03005380, gRapMenInfo.unkA, func_080398b4(1), 0, 1, 0x7f, 0);
+    gRapMenInfo.unk10 = func_0800c3a4(0x24);
+    func_08002634(D_089e652c[gRapMenInfo.unk0][0]);
     func_08002634(&s_tom_M_seqData);
 }
 
 void func_08039c60(void) {
-    if (!D_030055d0->gameInfo.rapMen.unk14) {
-        func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unkA, func_080398b4(8), 0, 1, 0x7f, 0);
-        D_030055d0->gameInfo.rapMen.unk10 = func_0800c3a4(0x3c);
+    if (!gRapMenInfo.unk14) {
+        func_0804d8f8(D_03005380, gRapMenInfo.unkA, func_080398b4(8), 0, 1, 0x7f, 0);
+        gRapMenInfo.unk10 = func_0800c3a4(0x3c);
         func_08002634(&s_RC_seqData);
     }
     func_0800bc40();
 }
 
 void func_08039cb8(void) {
-    func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unkA, func_080398b4(9), 0, 1, 0x7f, 0);
-    D_030055d0->gameInfo.rapMen.unk10 = func_0800c3a4(0x24);
-    func_08002634(D_089e65f0[D_030055d0->unk0]);
+    func_0804d8f8(D_03005380, gRapMenInfo.unkA, func_080398b4(9), 0, 1, 0x7f, 0);
+    gRapMenInfo.unk10 = func_0800c3a4(0x24);
+    func_08002634(D_089e65f0[gRapMenInfo.unk0]);
     func_0800bc40();
 }
 
 void func_08039d10(void) {
-    if (!D_030055d0->gameInfo.rapMen.unkE) {
-        func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unk8, func_080398b4(0xA), 0, 1, 0x7f, 0);
+    if (!gRapMenInfo.unkE) {
+        func_0804d8f8(D_03005380, gRapMenInfo.unk8, func_080398b4(0xA), 0, 1, 0x7f, 0);
     }
-    if (!D_030055d0->gameInfo.rapMen.unk10) {
-        func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unkA, func_080398b4(9), 0, 1, 0x7f, 0);
+    if (!gRapMenInfo.unk10) {
+        func_0804d8f8(D_03005380, gRapMenInfo.unkA, func_080398b4(9), 0, 1, 0x7f, 0);
     }
 }
 
@@ -161,13 +163,13 @@ void func_08039d7c(u32 arg0) {
     u32 temp;
 
     if (!arg0) {
-        func_0804d770(D_03005380, D_030055d0->gameInfo.rapMen.unkC, 0);
+        func_0804d770(D_03005380, gRapMenInfo.unkC, 0);
         return;
     }
-    temp = func_08004b98(D_030055d0->gameInfo.rapMen.unk4, arg0, 1, 8);
-    func_08007b04(D_030055d0->gameInfo.rapMen.unk4, D_030055d0->gameInfo.rapMen.unkC);
-    func_0804d8f8(D_03005380, D_030055d0->gameInfo.rapMen.unkC, temp, 0, 0, 0, 0);
-    func_0804d770(D_03005380, D_030055d0->gameInfo.rapMen.unkC, 1);
+    temp = func_08004b98(gRapMenInfo.unk4, arg0, 1, 8);
+    func_08007b04(gRapMenInfo.unk4, gRapMenInfo.unkC);
+    func_0804d8f8(D_03005380, gRapMenInfo.unkC, temp, 0, 0, 0, 0);
+    func_0804d770(D_03005380, gRapMenInfo.unkC, 1);
 }
 
 void func_08039df8(void) {

--- a/src/scenes/rap_men.inc.c
+++ b/src/scenes/rap_men.inc.c
@@ -2,15 +2,16 @@
 #include "src/code_08007468.h"
 #include "src/code_0800b778.h"
 
+// For readability. !TODO - CHANGE/REMOVE
 #define gRapMenInfo D_030055d0->gameInfo.rapMen
 
-extern char *D_0805a8b0;
+extern char *D_0805a8b0;    // ??? !TODO - Verify
 
 extern u32 **D_089e63f8[];  // Animation Index (index of pairs of animation pointers; 0 = Rap Men; 1 = Rap Women)
 extern u32 D_089e6424;      // GFX-related Null
 extern u32 *D_089e6518[];   // GFX Struct Index
-extern u8 D_089e6520;
-extern u8 D_089e6525;
+extern u8  D_089e6520;
+extern u8  D_089e6525;
 
 const struct SeqData *D_089e652c[2][2];
 extern u32 D_089e65f0[];
@@ -21,9 +22,10 @@ extern const struct SequenceData s_SD1_seqData;
 extern const struct SequenceData s_CC4_seqData;
 
 // !TODO
-extern void func_0804d770(u32, u32, u16);
-extern void func_0804cebc(u32, s16, s8);
-extern u32 func_0804d160(u32, u32 *, s8, u32, u32, u32, u32, u32, u32);
+extern u32 *func_08004c0c(u32 *, char **, u32, u32);
+extern void func_0804cebc(s32, s16, s8);
+extern u32  func_0804d160(s32, u32 *, s8, s16, s16, u16, s8, s8, u16);
+extern void func_0804d770(s32, s16, u16);
 
 
 u32 *func_080398b4(u32 arg0) {

--- a/src/scenes/rap_men.inc.c
+++ b/src/scenes/rap_men.inc.c
@@ -6,8 +6,8 @@
 extern char *D_0805a8b0;
 
 extern u32 *D_089e63f8[];
-extern u32 D_089e6424;
-extern u32 D_089e6518[];
+extern u32 D_089e6424;    // GFX-related Null
+extern u32 *D_089e6518[]; // GFX Struct Index
 extern u8 D_089e6520;
 extern u8 D_089e6525;
 

--- a/src/scenes/rhythm_tweezers.inc.c
+++ b/src/scenes/rhythm_tweezers.inc.c
@@ -31,6 +31,11 @@ extern u32 D_0600f800;    // VRAM BG Map for vegetable textures (right).
 extern u32 D_03004b22;    // Unknown Value
 extern s16 D_03004b10[];  // Screen Position Struct/Array (?)
 
+// External Functions:
+extern void func_0804cebc(s32, s16, s8);
+extern void func_0804d770(s32, s16, u16);
+extern void func_0804dae0(s32, s16, s8, u32, u32);
+
 
 /* RHYTHM TWEEZERS */
 

--- a/src/scenes/rhythm_tweezers.inc.c
+++ b/src/scenes/rhythm_tweezers.inc.c
@@ -37,7 +37,7 @@ extern s16 D_03004b10[];  // Screen Position Struct/Array (?)
 // [func_0802e750] SUB - Initialise Vegetable Face
 void func_0802e750(void) {
     struct RhythmTweezersVegetable *vegetable = &gRhythmTweezersInfo.vegetable;
-    u8 ver = (D_030055d0->unk0 % 3);
+    u8 ver = (gRhythmTweezersInfo.unk0 % 3);
 
     vegetable->entity0 = func_0804d160(D_03005380, D_089e3d98[ver], 0, 0x78, 0x10, 0x4800, -1, 0, 0);
     func_0804db44(D_03005380, vegetable->entity0, &gRhythmTweezersInfo.unk8E, &D_03004b22);
@@ -282,7 +282,7 @@ void func_0802ec60(void) {
     u32 temp;
 
     func_0800c604(0);
-    temp = func_08002ee0(func_0800c3b8(), D_089e3ff4[D_030055d0->unk0], 0x2000);
+    temp = func_08002ee0(func_0800c3b8(), D_089e3ff4[gRhythmTweezersInfo.unk0], 0x2000);
     func_08005d38(temp, &func_0802ec50, 0);
 }
 
@@ -302,7 +302,7 @@ void func_0802eccc(u8 arg0) {
     u32 temp;
 
     // Standard game setup.
-    D_030055d0->unk0 = arg0;
+    gRhythmTweezersInfo.unk0 = arg0;
     func_0802eca0(); // Load graphics.
     func_0800e0ec();
     func_0800e0a0(0, 1, 0, -0xa0, 2, 0x1c, 0x8000);

--- a/src/scenes/rhythm_tweezers.inc.c
+++ b/src/scenes/rhythm_tweezers.inc.c
@@ -1,5 +1,6 @@
 #include "src/code_08001360.h"
 #include "src/code_08007468.h"
+#include "src/code_0800b778.h"
 
 // For readability. !TODO - CHANGE/REMOVE
 #define gRhythmTweezersInfo D_030055d0->gameInfo.rhythmTweezers

--- a/src/scenes/wizards_waltz.inc.c
+++ b/src/scenes/wizards_waltz.inc.c
@@ -62,7 +62,7 @@ void func_08044a10(u32 arg0) {
     u8 i;
 
     // Load graphical assets and other basic functionality.
-    D_030055d0->unk0 = arg0;
+    gWizardsWaltzInfo.version = arg0;
     func_080449e4();
     func_0800e0ec();
     func_0800e0a0(1, 1, 0, 0, 0, 29, 1);

--- a/src/scenes/wizards_waltz.inc.c
+++ b/src/scenes/wizards_waltz.inc.c
@@ -20,8 +20,8 @@ extern u32 D_08932edc[]; // Animation: "shadow"
 extern const struct SequenceData s_witch_furu_seqData; // Sound for inputting without a cue.
 
 // Additional Data - Wizard's Waltz:
-extern u32 D_089e9f10; // GFX-related Null
-extern u32 D_089e9f14[]; // GFX Array
+extern u32 D_089e9f10;   // GFX-related Null
+extern u32 D_089e9f14[]; // GFX Struct
 
 // Additional Data - Global:
 extern s16 D_03004afc; // Input Queue(?)
@@ -42,7 +42,7 @@ void func_080449b4(void) {
     u32 temp;
 
     func_0800c604(0);
-    temp = func_08002ee0(func_0800c3b8(), &D_089e9f14, 0x2000);
+    temp = func_08002ee0(func_0800c3b8(), D_089e9f14, 0x2000);
     func_08005d38(temp, func_080449a4, 0);
 }
 

--- a/src/scenes/wizards_waltz.inc.c
+++ b/src/scenes/wizards_waltz.inc.c
@@ -218,7 +218,7 @@ void func_08044e74_stub(void) {
 
 
 // [func_08044f94] CUE Behaviour
-u32 func_08044f94(u32 arg0, u32 arg1, u32 arg2) {
+u32 func_08044f94(u32 arg0, struct struct_080179f4_sub *arg1, u32 arg2) {
     if (arg2 > (gWizardsWaltzInfo.cycleInterval + func_0800c3a4(0x30))) {
         return 1;
 	} else {
@@ -228,13 +228,13 @@ u32 func_08044f94(u32 arg0, u32 arg1, u32 arg2) {
 
 
 // [func_08044fc0] CUE Despawn
-void func_08044fc0(u32 arg0, u32 *arg1) {
-    func_0800fc70(arg1[0]);
+void func_08044fc0(u32 arg0, struct struct_080179f4_sub *arg1, u32 arg2) {
+    func_0800fc70(arg1->unk0);
 }
 
 
 // [func_08044fcc] CUE Hit
-void func_08044fcc(u32 arg0, struct struct_080179f4_sub *arg1) {
+void func_08044fcc(u32 arg0, struct struct_080179f4_sub *arg1, u32 arg2) {
     u32 isTutorial;
 
     // Play animation: "sprout_grow"
@@ -257,7 +257,7 @@ void func_08044fcc(u32 arg0, struct struct_080179f4_sub *arg1) {
 
 
 // [func_0804503c] CUE Barely
-void func_0804503c(u32 arg0, struct struct_080179f4_sub *arg1) {
+void func_0804503c(u32 arg0, struct struct_080179f4_sub *arg1, u32 arg2) {
     u32 temp;
     u32 isTutorial;
 
@@ -292,7 +292,7 @@ void func_0804503c(u32 arg0, struct struct_080179f4_sub *arg1) {
 
 
 // [func_080450d0] CUE Miss
-void func_080450d0(u32 arg0, struct struct_080179f4_sub *arg1) {
+void func_080450d0(u32 arg0, struct struct_080179f4_sub *arg1, u32 arg2) {
     // Unknown function - likely related to score.
     func_0800bc40();
 }

--- a/src/scenes/wizards_waltz.inc.c
+++ b/src/scenes/wizards_waltz.inc.c
@@ -83,7 +83,7 @@ void func_08044a10(u32 arg0) {
 
     // Create sparkle entities.
     for (i = 0; i < 10; i++) {
-        u32 entity;
+        struct ScaledEntity *entity;
         gWizardsWaltzInfo.sparkle[i].state = 0;
         entity = func_0800fa6c(D_08932c8c, 0, 0, 0, 0, 0x80, 0, 1, 0, 0, 0);
         gWizardsWaltzInfo.sparkle[i].entity = entity;
@@ -105,7 +105,7 @@ void func_08044b80(u32 arg0) {
 
 
 // [func_08044ba8] SUB Func_00 - Update Entity Position
-void func_08044ba8(u32 arg0, s32 arg1, s32 arg2, u32 arg3) {
+void func_08044ba8(struct ScaledEntity *arg0, s32 arg1, s32 arg2, u32 arg3) {
     s32 temp;
     u32 temp1 = arg3 - gWizardsWaltzInfo.globalScale;
 


### PR DESCRIPTION
- Redefine various functions and data structures.
- Add various function externs and code `#include`s to all currently decompiled scenes.
- Add minimal documentation for some data structure externs in Karate Man and Rap Men.
- Add readability macros for Karate Man (`gKarateManInfo`) and Rap Men (`gRapMenInfo`).
- Migrate `D_030055d0->unk0` to each struct in `gameInfo` union, in preparation of `prologue` merge.
- Revert documentation for Wizard's Waltz functions in `scenes.h` (again) and modify comments to match format used for Rhythm Tweezers.