### PR TITLE
Update make clean target to ignore audio/samples and audio/sequences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,9 @@ export INCLUDE	:=	-I $(foreach dir,$(INCLUDES),$(wildcard $(dir)/*.h)) \
 					-I $(foreach dir,$(LIBDIRS),-I $(dir)/include) \
 					-I $(CURDIR)/$(BUILD)
 
+ALL_BUILDFILES := $(wildcard $(BUILD)/*) $(wildcard $(BUILD)/audio/*)
+BUILDFILES := $(filter-out $(BUILD)/audio $(BUILD)/audio/samples $(BUILD)/audio/sequences, $(ALL_BUILDFILES))
+
 #export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
 
 ifeq (,$(wildcard baserom.gba))
@@ -131,7 +134,7 @@ default: $(OUTPUT).gba
 #---------------------------------------------------------------------------------
 clean:
 	$(V)echo clean ...
-	$(V)rm -fr $(BUILD)
+	$(V)rm -f -r $(BUILDFILES)
 
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
Pull request with substance + ratio
Replaces the existing `clean` target