### PR TITLE
Replace hardcoded array values with macros

### DIFF
--- a/include/engines/bon_odori.h
+++ b/include/engines/bon_odori.h
@@ -5,46 +5,10 @@
 
 #include "games/bon_odori/graphics/bon_odori_graphics.h"
 
-#define BON_ODORI_DONPAN_AMOUNT 4
-
-// Engine Types:
-struct BonOdoriText {
-    s16 textSprite;
-    s16 highlightSprite;
-    struct Animation *anim;
-    s16 leftEdge;
-    u16 width;
-};
-
-struct BonOdoriEngineData {
-    u8 version;
-    struct BitmapFontOBJ *unk4;
-    struct BonOdoriText lyrics[4];
-    u8 currentLyric;
-    s16 lyricsX;
-    s16 lyricsY;
-    s16 yaguraSprite;
-    u16 yaguraFrownTimer;
-    u8 yaguraNoticedMistake;
-    s16 donpanSprites[BON_ODORI_DONPAN_AMOUNT];
-    u16 donpanAnimTimers[BON_ODORI_DONPAN_AMOUNT];
-    u8 donpanEmoteTimer;
-    u8 donpanEmoteAnim;
-    const u16 *srcBgPal;
-    const u16 *srcObjPal;
-    u16 darkBgPalBuf[32][16];
-    u16 darkObjPalBuf[32][16];
-    u16 mistimedClaps;
-    u8 currentClapAnim;
-    u16 playerClapTimer;
-};
-
-struct BonOdoriCue {
-    u8 type;
-};
-
-
 // Engine Macros/Enums:
+#define BON_ODORI_DONPAN_AMOUNT 4
+#define BON_ODORI_LYRIC_AMOUNT 4
+
 enum BonOdoriAnimationsEnum {
     BON_ODORI_ANIM_DONPAN1_BEAT,
     BON_ODORI_ANIM_DONPAN2_BEAT,
@@ -91,6 +55,43 @@ enum BonOdoriDonpanAnimationsEnum {
     DONPAN_ANIM_HAPPY,
     DONPAN_ANIM_VERY_HAPPY,
     DONPAN_ANIM_SPIN
+};
+
+
+// Engine Types:
+struct BonOdoriText {
+    s16 textSprite;
+    s16 highlightSprite;
+    struct Animation *anim;
+    s16 leftEdge;
+    u16 width;
+};
+
+struct BonOdoriEngineData {
+    u8 version;
+    struct BitmapFontOBJ *unk4;
+    struct BonOdoriText lyrics[BON_ODORI_LYRIC_AMOUNT];
+    u8 currentLyric;
+    s16 lyricsX;
+    s16 lyricsY;
+    s16 yaguraSprite;
+    u16 yaguraFrownTimer;
+    u8 yaguraNoticedMistake;
+    s16 donpanSprites[BON_ODORI_DONPAN_AMOUNT];
+    u16 donpanAnimTimers[BON_ODORI_DONPAN_AMOUNT];
+    u8 donpanEmoteTimer;
+    u8 donpanEmoteAnim;
+    const u16 *srcBgPal;
+    const u16 *srcObjPal;
+    u16 darkBgPalBuf[32][16];
+    u16 darkObjPalBuf[32][16];
+    u16 mistimedClaps;
+    u8 currentClapAnim;
+    u16 playerClapTimer;
+};
+
+struct BonOdoriCue {
+    u8 type;
 };
 
 

--- a/include/engines/bon_odori.h
+++ b/include/engines/bon_odori.h
@@ -5,6 +5,8 @@
 
 #include "games/bon_odori/graphics/bon_odori_graphics.h"
 
+#define BON_ODORI_DONPAN_AMOUNT 4
+
 // Engine Types:
 struct BonOdoriText {
     s16 textSprite;
@@ -24,8 +26,8 @@ struct BonOdoriEngineData {
     s16 yaguraSprite;
     u16 yaguraFrownTimer;
     u8 yaguraNoticedMistake;
-    s16 donpanSprites[4];
-    u16 donpanAnimTimers[4];
+    s16 donpanSprites[BON_ODORI_DONPAN_AMOUNT];
+    u16 donpanAnimTimers[BON_ODORI_DONPAN_AMOUNT];
     u8 donpanEmoteTimer;
     u8 donpanEmoteAnim;
     const u16 *srcBgPal;

--- a/include/engines/bouncy_road.h
+++ b/include/engines/bouncy_road.h
@@ -5,20 +5,20 @@
 
 #include "games/bouncy_road/graphics/bouncy_road_graphics.h"
 
+// Engine Macros/Enums:
+enum BouncyRoadVersionsEnum {
+    BOUNCY_ROAD_VER_0,
+    BOUNCY_ROAD_VER_REMIX_5,
+    BOUNCY_ROAD_VER_2
+};
+
+
 // Engine Types:
 struct BouncyRoadEngineData {
     u8 pad[0x1dc];
 };
 
 struct BouncyRoadCue {
-};
-
-
-// Engine Macros/Enums:
-enum BouncyRoadVersionsEnum {
-    BOUNCY_ROAD_VER_0,
-    BOUNCY_ROAD_VER_REMIX_5,
-    BOUNCY_ROAD_VER_2
 };
 
 

--- a/include/engines/clappy_trio.h
+++ b/include/engines/clappy_trio.h
@@ -5,16 +5,6 @@
 
 #include "games/clappy_trio/graphics/clappy_trio_graphics.h"
 
-// Engine Types:
-struct ClappyTrioEngineData {
-    u8 pad[0x1c];
-};
-
-struct ClappyTrioCue {
-    /* add fields here */
-};
-
-
 // Engine Macros/Enums:
 enum ClappyTrioVersionsEnum {
     CLAPPY_TRIO_VER_0,
@@ -30,6 +20,16 @@ enum ClappyTrioAnimationsEnum {
     CLAPPY_TRIO_ANIM_YOU,
     CLAPPY_TRIO_ANIM_SIGN,
     CLAPPY_TRIO_ANIM_TEXT_BOX
+};
+
+
+// Engine Types:
+struct ClappyTrioEngineData {
+    u8 pad[0x1c];
+};
+
+struct ClappyTrioCue {
+    /* add fields here */
 };
 
 

--- a/include/engines/drum_intro.h
+++ b/include/engines/drum_intro.h
@@ -6,6 +6,15 @@
 
 #include "games/drum_intro/graphics/drum_intro_graphics.h"
 
+// Engine Macros/Enums:
+enum DrumIntroVersionsEnum {
+    ENGINE_VER_DRUM_INTRO_TEACHER,
+    ENGINE_VER_DRUM_INTRO_PLAYER,
+    ENGINE_VER_DRUM_INTRO_TANUKI_MONKEY,
+    ENGINE_VER_DRUM_INTRO_CUTSCENE
+};
+
+
 // Engine Types:
 struct DrumIntroEngineData {
     u8 pad[0x3b4];
@@ -25,15 +34,6 @@ struct DrumKitCueData {
     const DrumKitCueFunc func10;
     const DrumKitCueFunc func14;
     u32 unk18;
-};
-
-
-// Engine Macros/Enums:
-enum DrumIntroVersionsEnum {
-    ENGINE_VER_DRUM_INTRO_TEACHER,
-    ENGINE_VER_DRUM_INTRO_PLAYER,
-    ENGINE_VER_DRUM_INTRO_TANUKI_MONKEY,
-    ENGINE_VER_DRUM_INTRO_CUTSCENE
 };
 
 

--- a/include/engines/drum_live.h
+++ b/include/engines/drum_live.h
@@ -6,16 +6,6 @@
 
 #include "games/drum_live/graphics/drum_live_graphics.h"
 
-// Engine Types:
-struct DrumLiveEngineData {
-    u8 pad[0x1820];
-};
-
-struct DrumLiveCue {
-    /* add fields here */
-};
-
-
 // Engine Macros/Enums:
 enum DrumLiveVersionsEnum {
     ENGINE_VER_DRUM_GIRLS_LIVE,
@@ -66,6 +56,16 @@ enum DrumLiveAnimationsEnum {
     LIVE_ANIM_BUSY_ICON,
     LIVE_ANIM_MICROPHONE,
     LIVE_ANIM_LIGHT_FLASH
+};
+
+
+// Engine Types:
+struct DrumLiveEngineData {
+    u8 pad[0x1820];
+};
+
+struct DrumLiveCue {
+    /* add fields here */
 };
 
 

--- a/include/engines/drum_live_menu.h
+++ b/include/engines/drum_live_menu.h
@@ -5,6 +5,14 @@
 
 #include "games/drum_live/graphics/drum_live_menu_graphics.h"
 
+// Engine Macros/Enums:
+enum DrumLiveMenuPostersEnum {
+    POSTER_DRUM_GIRLS_LIVE,
+    POSTER_DRUM_BOYS_LIVE,
+    POSTER_DRUM_SAMURAI_BAND_LIVE
+};
+
+
 // Engine Types:
 struct DrumLiveMenuEngineData {
     u8 pad[0x1c];
@@ -12,14 +20,6 @@ struct DrumLiveMenuEngineData {
 
 struct DrumLiveMenuCue {
     /* add fields here */
-};
-
-
-// Engine Macros/Enums:
-enum DrumLiveMenuPostersEnum {
-    POSTER_DRUM_GIRLS_LIVE,
-    POSTER_DRUM_BOYS_LIVE,
-    POSTER_DRUM_SAMURAI_BAND_LIVE
 };
 
 

--- a/include/engines/drum_studio.h
+++ b/include/engines/drum_studio.h
@@ -7,6 +7,26 @@
 
 #include "games/drum_studio/graphics/drum_studio_graphics.h"
 
+// Engine Macros/Enums:
+#define DRUM_STUDIO_ACCURACY_LIGHTS_AMOUNT 7
+
+enum DrumLessonsVersionsEnum {
+    ENGINE_VER_DRUM_STUDIO_0,
+    ENGINE_VER_DRUM_STUDIO_PLAY,
+    ENGINE_VER_DRUM_STUDIO_2,
+    ENGINE_VER_DRUM_STUDIO_LISTEN,
+    ENGINE_VER_DRUM_LESSONS
+};
+
+enum DrumLessonsRanksEnum {
+    DRUM_LESSON_RANK_0,
+    DRUM_LESSON_RANK_C,
+    DRUM_LESSON_RANK_B,
+    DRUM_LESSON_RANK_A,
+    DRUM_LESSON_RANK_S,
+};
+
+
 // Engine Types:
 struct StudioDrummer {
     s16 snareDrum;
@@ -106,7 +126,7 @@ struct DrumStudioEngineData {
     u8 unk563;
     u16 unk564;
     u16 null566;
-    s16 accuracyLightSprites[7]; // 0x568
+    s16 accuracyLightSprites[DRUM_STUDIO_ACCURACY_LIGHTS_AMOUNT]; // 0x568
     u8 unk576;
     struct SoundPlayer *musicPlayer; // 0x578
     u32 unk57C;
@@ -142,24 +162,6 @@ struct DrumTeacherExpression {
     struct Animation *head;
     struct Animation *rightArm;
     struct Animation *leftArm;
-};
-
-
-// Engine Macros/Enums:
-enum DrumLessonsVersionsEnum {
-    ENGINE_VER_DRUM_STUDIO_0,
-    ENGINE_VER_DRUM_STUDIO_PLAY,
-    ENGINE_VER_DRUM_STUDIO_2,
-    ENGINE_VER_DRUM_STUDIO_LISTEN,
-    ENGINE_VER_DRUM_LESSONS
-};
-
-enum DrumLessonsRanksEnum {
-    DRUM_LESSON_RANK_0,
-    DRUM_LESSON_RANK_C,
-    DRUM_LESSON_RANK_B,
-    DRUM_LESSON_RANK_A,
-    DRUM_LESSON_RANK_S,
 };
 
 

--- a/include/engines/fireworks.h
+++ b/include/engines/fireworks.h
@@ -5,6 +5,61 @@
 
 #include "games/fireworks/graphics/fireworks_graphics.h"
 
+// Engine Macros/Enums:
+#define FIREWORKS_PARTICLE_AMOUNT 72
+
+enum FireworksPatternsEnum {
+    FIREWORKS_PATTERN_L3,           // Left;    3 Layers
+    FIREWORKS_PATTERN_C3,           // Centre;  3 Layers
+    FIREWORKS_PATTERN_R3,           // Right;   3 Layers
+    FIREWORKS_PATTERN_LL2,          // Far-Left;    2 Layers
+    FIREWORKS_PATTERN_CL2,          // Mid-Left;    2 Layers (unused)
+    FIREWORKS_PATTERN_CR2,          // Mid-Right;   2 Layers (unused)
+    FIREWORKS_PATTERN_RR2,          // Far-Right;   2 Layers
+    FIREWORKS_PATTERN_L3_BARELY,    // Centre;  1 Layer
+    FIREWORKS_PATTERN_C3_BARELY,    // Centre;  1 Layer
+    FIREWORKS_PATTERN_R3_BARELY,    // Centre;  1 Layer
+    FIREWORKS_PATTERN_LL2_BARELY,   // Centre;  1 Layer
+    FIREWORKS_PATTERN_CL2_BARELY,   // Centre;  1 Layer (unused)
+    FIREWORKS_PATTERN_CR2_BARELY,   // Centre;  1 Layer (unused)
+    FIREWORKS_PATTERN_RR2_BARELY,   // Centre;  1 Layer
+    FIREWORKS_PATTERN_SP_STAR,      // Centre;  Special - Large Star
+    FIREWORKS_PATTERN_SP_CIRCLE,    // Centre;  Special - Circle
+    FIREWORKS_PATTERN_SP_SPIRAL,    // Centre;  Special - Spiral
+    FIREWORKS_PATTERN_SP_SMILE,     // Centre;  Special - Smile
+    FIREWORKS_PATTERN_SP_TSUNKU,    // Centre;  Special - ï¿½? (unused)
+    FIREWORKS_PATTERN_TAIKO_BOMBER, // Hawfinch Taiko Bomber
+};
+
+enum FireworksParticlesEnum {
+    FIREWORKS_PARTICLE_RED,
+    FIREWORKS_PARTICLE_GREEN,
+    FIREWORKS_PARTICLE_BLUE,
+    FIREWORKS_PARTICLE_MULTI
+};
+
+enum FireworksPatternModesEnum {
+    FIREWORKS_PATTERN_MODE_0,
+    FIREWORKS_PATTERN_MODE_1,
+    FIREWORKS_PATTERN_MODE_TAIKO_BOMBER,
+    FIREWORKS_PATTERN_MODE_USE_TABLE
+};
+
+enum FireworksCueTypesEnum {
+    FIREWORKS_CUE_TYPE_SPIRIT_SPARKLER,
+    FIREWORKS_CUE_TYPE_NORMAL_FIREWORK,
+    FIREWORKS_CUE_TYPE_HAWFINCH_TAIKO_BOMBER
+};
+
+enum FireworksSoundsEnum {
+    FIREWORKS_SFX_COME_ON,
+    FIREWORKS_SFX_ONE,
+    FIREWORKS_SFX_TWO,
+    FIREWORKS_SFX_THREE,
+    FIREWORKS_SFX_NUEI
+};
+
+
 // Engine Types:
 struct FireworksEngineData {
     u8  version;        // Version Number
@@ -20,7 +75,7 @@ struct FireworksEngineData {
         u8  initAngle;  // Trajectory Angle
         s32 initVel;    // Trajectory Velocity
         u8  colour;     // Colour ID { 0..3 }
-    } particles[72];        // Firework Particle Entities
+    } particles[FIREWORKS_PARTICLE_AMOUNT];        // Firework Particle Entities
     s16 skipTutorialSprite; // Unused "Start to Skip" Text (Sprite)
     u8  screenBrightness;   // Screen Brightness (for Taiko Bomber screen flash)
     u8  patternTableNext;   // Current Position in Fireworks 1 Pattern Table
@@ -51,59 +106,6 @@ struct FireworksPatternColours {
 struct FireworksParticleTrajectory {
     s32 initAngle; // Uses precision of sins2 table.
     s32 initVelocity;
-};
-
-
-// Engine Macros/Enums:
-enum FireworksPatternsEnum {
-    FIREWORKS_PATTERN_L3,           // Left;    3 Layers
-    FIREWORKS_PATTERN_C3,           // Centre;  3 Layers
-    FIREWORKS_PATTERN_R3,           // Right;   3 Layers
-    FIREWORKS_PATTERN_LL2,          // Far-Left;    2 Layers
-    FIREWORKS_PATTERN_CL2,          // Mid-Left;    2 Layers (unused)
-    FIREWORKS_PATTERN_CR2,          // Mid-Right;   2 Layers (unused)
-    FIREWORKS_PATTERN_RR2,          // Far-Right;   2 Layers
-    FIREWORKS_PATTERN_L3_BARELY,    // Centre;  1 Layer
-    FIREWORKS_PATTERN_C3_BARELY,    // Centre;  1 Layer
-    FIREWORKS_PATTERN_R3_BARELY,    // Centre;  1 Layer
-    FIREWORKS_PATTERN_LL2_BARELY,   // Centre;  1 Layer
-    FIREWORKS_PATTERN_CL2_BARELY,   // Centre;  1 Layer (unused)
-    FIREWORKS_PATTERN_CR2_BARELY,   // Centre;  1 Layer (unused)
-    FIREWORKS_PATTERN_RR2_BARELY,   // Centre;  1 Layer
-    FIREWORKS_PATTERN_SP_STAR,      // Centre;  Special - Large Star
-    FIREWORKS_PATTERN_SP_CIRCLE,    // Centre;  Special - Circle
-    FIREWORKS_PATTERN_SP_SPIRAL,    // Centre;  Special - Spiral
-    FIREWORKS_PATTERN_SP_SMILE,     // Centre;  Special - Smile
-    FIREWORKS_PATTERN_SP_TSUNKU,    // Centre;  Special - â™? (unused)
-    FIREWORKS_PATTERN_TAIKO_BOMBER, // Hawfinch Taiko Bomber
-};
-
-enum FireworksParticlesEnum {
-    FIREWORKS_PARTICLE_RED,
-    FIREWORKS_PARTICLE_GREEN,
-    FIREWORKS_PARTICLE_BLUE,
-    FIREWORKS_PARTICLE_MULTI
-};
-
-enum FireworksPatternModesEnum {
-    FIREWORKS_PATTERN_MODE_0,
-    FIREWORKS_PATTERN_MODE_1,
-    FIREWORKS_PATTERN_MODE_TAIKO_BOMBER,
-    FIREWORKS_PATTERN_MODE_USE_TABLE
-};
-
-enum FireworksCueTypesEnum {
-    FIREWORKS_CUE_TYPE_SPIRIT_SPARKLER,
-    FIREWORKS_CUE_TYPE_NORMAL_FIREWORK,
-    FIREWORKS_CUE_TYPE_HAWFINCH_TAIKO_BOMBER
-};
-
-enum FireworksSoundsEnum {
-    FIREWORKS_SFX_COME_ON,
-    FIREWORKS_SFX_ONE,
-    FIREWORKS_SFX_TWO,
-    FIREWORKS_SFX_THREE,
-    FIREWORKS_SFX_NUEI
 };
 
 

--- a/include/engines/karate_man.h
+++ b/include/engines/karate_man.h
@@ -6,6 +6,47 @@
 
 #include "games/karate_man/graphics/karate_man_graphics.h"
 
+// Engine Macros/Enums:
+#define KARATE_PALETTE_NORMAL 0
+#define KARATE_PALETTE_SERIOUS 1
+
+enum KarateVersionsEnum {
+    KARATE_VER_0,
+    KARATE_VER_FACES,
+    KARATE_VER_SERIOUS,
+    KARATE_VER_PURPLE
+};
+
+enum KarateJoeFacesEnum {
+    KARATE_JOE_EMOTE_0,
+    KARATE_JOE_EMOTE_1,
+    KARATE_JOE_EMOTE_2
+};
+
+enum KarateObjectsEnum {
+    KARATE_OBJECT_POT,
+    KARATE_OBJECT_ROCK,
+    KARATE_OBJECT_SOCCER_BALL,
+    KARATE_OBJECT_BOMB,
+    KARATE_OBJECT_LIGHT_BULB,
+};
+
+enum KarateCuesEnum {
+    KARATE_CUE_POT,
+    KARATE_CUE_SOCCER_BALL,
+    KARATE_CUE_POT_STRICT,
+    KARATE_CUE_03_NULL,
+    KARATE_CUE_ROCK,
+    KARATE_CUE_BOMB,
+    KARATE_CUE_06_NULL,
+    KARATE_CUE_07_NULL,
+    KARATE_CUE_LIGHT_BULB,
+    KARATE_CUE_09_NULL,
+    KARATE_CUE_0A_NULL,
+    KARATE_CUE_0B_NULL,
+};
+
+
 // Engine Types:
 struct KarateManEngineData {
     u8 version;     // 0 = Karate Man; 1 = Karate Man (BG Faces); 2 = Karate Man ("Serious Mode"); 3 = Karate Man 2
@@ -57,47 +98,6 @@ struct KarateManCue {
     s8 unk2C;      // Value:  Object Angle
     u8 unk2D;      // Value:  Object Rotation
     s16 unk2E;     // Value:  unk2E
-};
-
-
-// Engine Macros/Enums:
-#define KARATE_PALETTE_NORMAL 0
-#define KARATE_PALETTE_SERIOUS 1
-
-enum KarateVersionsEnum {
-    KARATE_VER_0,
-    KARATE_VER_FACES,
-    KARATE_VER_SERIOUS,
-    KARATE_VER_PURPLE
-};
-
-enum KarateJoeFacesEnum {
-    KARATE_JOE_EMOTE_0,
-    KARATE_JOE_EMOTE_1,
-    KARATE_JOE_EMOTE_2
-};
-
-enum KarateObjectsEnum {
-    KARATE_OBJECT_POT,
-    KARATE_OBJECT_ROCK,
-    KARATE_OBJECT_SOCCER_BALL,
-    KARATE_OBJECT_BOMB,
-    KARATE_OBJECT_LIGHT_BULB,
-};
-
-enum KarateCuesEnum {
-    KARATE_CUE_POT,
-    KARATE_CUE_SOCCER_BALL,
-    KARATE_CUE_POT_STRICT,
-    KARATE_CUE_03_NULL,
-    KARATE_CUE_ROCK,
-    KARATE_CUE_BOMB,
-    KARATE_CUE_06_NULL,
-    KARATE_CUE_07_NULL,
-    KARATE_CUE_LIGHT_BULB,
-    KARATE_CUE_09_NULL,
-    KARATE_CUE_0A_NULL,
-    KARATE_CUE_0B_NULL,
 };
 
 

--- a/include/engines/marching_orders.h
+++ b/include/engines/marching_orders.h
@@ -5,22 +5,6 @@
 
 #include "games/marching_orders/graphics/marching_orders_graphics.h"
 
-// Engine Types:
-struct MarchingOrdersEngineData {
-    u8 pad[0x48];
-};
-
-struct MarchingOrdersCue {
-    /* add fields here */
-};
-
-struct MarchingSfxData {
-    struct SequenceData *sound;
-    u16 volume;
-    s16 pitch;
-};
-
-
 // Engine Macros/Enums:
 enum MarchingOrdersVersionsEnum {
     MARCHING_ORDERS_VER_0,
@@ -60,6 +44,22 @@ enum MarchingOrdersSoundEffectsEnum {
     MARCHING_SFX_CMD_LEFT_FACE,
     MARCHING_SFX_CMD_LEFT_FACE_F,
     MARCHING_SFX_CMD_TURN_LEFT
+};
+
+
+// Engine Types:
+struct MarchingOrdersEngineData {
+    u8 pad[0x48];
+};
+
+struct MarchingOrdersCue {
+    /* add fields here */
+};
+
+struct MarchingSfxData {
+    struct SequenceData *sound;
+    u16 volume;
+    s16 pitch;
 };
 
 

--- a/include/engines/mechanical_horse.h
+++ b/include/engines/mechanical_horse.h
@@ -5,6 +5,15 @@
 
 #include "games/mechanical_horse/graphics/mechanical_horse_graphics.h"
 
+// Engine Macros/Enums:
+enum HorseLessonsEnum {
+    HORSE_LESSON_1_WALK,
+    HORSE_LESSON_2_TROT,
+    HORSE_LESSON_3_CANTER,
+    HORSE_LESSON_4_GALLOP
+};
+
+
 // Engine Types:
 struct MechanicalHorseEngineData {
     u8 pad[0x310];
@@ -17,15 +26,6 @@ struct MechanicalHorseCue {
 struct MechanicalHorseBG {
     Palette *palette;
     const struct GraphicsTable *gfxTable;
-};
-
-
-// Engine Macros/Enums:
-enum HorseLessonsEnum {
-    HORSE_LESSON_1_WALK,
-    HORSE_LESSON_2_TROT,
-    HORSE_LESSON_3_CANTER,
-    HORSE_LESSON_4_GALLOP
 };
 
 

--- a/include/engines/night_walk.h
+++ b/include/engines/night_walk.h
@@ -5,6 +5,28 @@
 
 #include "games/night_walk/graphics/night_walk_graphics.h"
 
+// Engine Macros/Enums:
+#define NIGHT_WALK_STAR_AMOUNT 32
+
+enum NightWalkVersionsEnum {
+    NIGHT_WALK_VER_0,
+    NIGHT_WALK_VER_1 // Unused
+};
+
+enum NightWalkCuesEnum {
+    NIGHT_WALK_CUE_HEART,
+    NIGHT_WALK_CUE_LOLLIPOP,
+    NIGHT_WALK_CUE_UMBRELLA,
+    NIGHT_WALK_CUE_HEART_2,
+    NIGHT_WALK_CUE_STAR_WAND
+};
+
+#define DRUMTECH_NOTE_FUNC 0xFFFF
+#define DRUMTECH_NOTE_REST 0xFFFE
+#define DRUMTECH_NOTE_END_SEQ 0xFF
+#define END_OF_DRUM_TECH_SEQUENCE { DRUMTECH_NOTE_END_SEQ, 0, 0, 0 }
+
+
 // Engine Types:
 struct DrumTechInstrument {
     s8 soundPlayerID;
@@ -92,7 +114,7 @@ struct NightWalkEngineData {
         u16 size;
         s32 x;
         s32 y;
-    } stars[32];
+    } stars[NIGHT_WALK_STAR_AMOUNT];
     s16 starsVOffset;
     u32 nextStar;
     u32 currentStarSize;
@@ -119,26 +141,6 @@ struct NightWalkCue {
     u8 hasFish;
     s16 fishSprite;
 };
-
-
-// Engine Macros/Enums:
-enum NightWalkVersionsEnum {
-    NIGHT_WALK_VER_0,
-    NIGHT_WALK_VER_1 // Unused
-};
-
-enum NightWalkCuesEnum {
-    NIGHT_WALK_CUE_HEART,
-    NIGHT_WALK_CUE_LOLLIPOP,
-    NIGHT_WALK_CUE_UMBRELLA,
-    NIGHT_WALK_CUE_HEART_2,
-    NIGHT_WALK_CUE_STAR_WAND
-};
-
-#define DRUMTECH_NOTE_FUNC 0xFFFF
-#define DRUMTECH_NOTE_REST 0xFFFE
-#define DRUMTECH_NOTE_END_SEQ 0xFF
-#define END_OF_DRUM_TECH_SEQUENCE { DRUMTECH_NOTE_END_SEQ, 0, 0, 0 }
 
 
 // Engine Definition Data:

--- a/include/engines/ninja_bodyguard.h
+++ b/include/engines/ninja_bodyguard.h
@@ -5,22 +5,6 @@
 
 #include "games/ninja_bodyguard/graphics/ninja_bodyguard_graphics.h"
 
-// Engine Types:
-struct NinjaBodyguardEngineData {
-    u8 pad[0x300];
-};
-
-struct NinjaBodyguardCue {
-    /* add fields here */
-};
-
-struct SpriteVector3 {
-    s16 x;
-    s16 y;
-    s16 z;
-};
-
-
 // Engine Macros/Enums:
 enum NinjaBodyguardVersionsEnum {
     ENGINE_VER_NINJA_BODYGUARD,
@@ -51,6 +35,22 @@ enum NinjaBodyguardAnimationsEnum {
     NINJA_ANIM_RAISE_SWORD,
     NINJA_ANIM_BUTTON_INDICATOR,
     NINJA_ANIM_CUTSCENE_ARROW
+};
+
+
+// Engine Types:
+struct NinjaBodyguardEngineData {
+    u8 pad[0x300];
+};
+
+struct NinjaBodyguardCue {
+    /* add fields here */
+};
+
+struct SpriteVector3 {
+    s16 x;
+    s16 y;
+    s16 z;
 };
 
 

--- a/include/engines/polyrhythm.h
+++ b/include/engines/polyrhythm.h
@@ -5,8 +5,22 @@
 
 #include "games/polyrhythm/graphics/polyrhythm_graphics.h"
 
+// Engine Macros/Enums:
 #define POLYRHYTHM_LINE_AMOUNT 2
 #define POLYRHYTHM_BLOCK_AMOUNT 16
+#define POLYRHYTHM_ROD_AMOUNT 8
+
+enum PolyrhythmVersionsEnum {
+    POLYRHYTHM_VER_0,
+    POLYRHYTHM_VER_REMIX,
+    POLYRHYTHM_VER_2
+};
+
+enum PolyrhythmLanesEnum {
+    POLYRHYTHM_LANE_UPSIDE,
+    POLYRHYTHM_LANE_DOWNSIDE
+};
+
 
 // Engine Types:
 struct PolyrhythmEngineData {
@@ -17,7 +31,7 @@ struct PolyrhythmEngineData {
         u32 unk0_b6:26;
         s16 sprite;
     } lanes[POLYRHYTHM_LINE_AMOUNT][POLYRHYTHM_BLOCK_AMOUNT];
-    u8 unk104[2];
+    u8 unk104[POLYRHYTHM_LINE_AMOUNT];
     struct PolyrhythmRod {
         u32 active:1;
         u32 unk0_b1:3;
@@ -40,7 +54,7 @@ struct PolyrhythmEngineData {
         s32 runningTime;
         s32 maxDuration;
         u16 timeUntilExplosion;
-    } rods[8];
+    } rods[POLYRHYTHM_ROD_AMOUNT];
     s16 aButtonArrowSprite;
     s16 dPadArrowSprite;
 };
@@ -57,19 +71,6 @@ struct PolyrhythmCue {
     u32 unused1C;
     u32 unused20;
     u32 unused24;
-};
-
-
-// Engine Macros/Enums:
-enum PolyrhythmVersionsEnum {
-    POLYRHYTHM_VER_0,
-    POLYRHYTHM_VER_REMIX,
-    POLYRHYTHM_VER_2
-};
-
-enum PolyrhythmLanesEnum {
-    POLYRHYTHM_LANE_UPSIDE,
-    POLYRHYTHM_LANE_DOWNSIDE
 };
 
 

--- a/include/engines/polyrhythm.h
+++ b/include/engines/polyrhythm.h
@@ -5,6 +5,9 @@
 
 #include "games/polyrhythm/graphics/polyrhythm_graphics.h"
 
+#define POLYRHYTHM_LINE_AMOUNT 2
+#define POLYRHYTHM_BLOCK_AMOUNT 16
+
 // Engine Types:
 struct PolyrhythmEngineData {
     u8 version;
@@ -13,7 +16,7 @@ struct PolyrhythmEngineData {
         u32 state:3;
         u32 unk0_b6:26;
         s16 sprite;
-    } lanes[2][16];
+    } lanes[POLYRHYTHM_LINE_AMOUNT][POLYRHYTHM_BLOCK_AMOUNT];
     u8 unk104[2];
     struct PolyrhythmRod {
         u32 active:1;

--- a/include/engines/power_calligraphy.h
+++ b/include/engines/power_calligraphy.h
@@ -5,22 +5,6 @@
 
 #include "games/power_calligraphy/graphics/power_calligraphy_graphics.h"
 
-// Engine Types:
-struct PowerCalligraphyEngineData {
-    u8 pad[0x218];
-};
-
-struct PowerCalligraphyCue {
-    /* add fields here */
-};
-
-struct PowerCalligraphyBrushMotion {
-    s8 x;
-    s8 y;
-    s8 playback;
-};
-
-
 // Engine Macros/Enums:
 enum PowerCalligraphyInputsEnum {
     POWER_CALLIGRAPHY_INPUT_ONORE1,
@@ -34,6 +18,22 @@ enum PowerCalligraphyInputsEnum {
     POWER_CALLIGRAPHY_INPUT_RE1,
     POWER_CALLIGRAPHY_INPUT_COMMA1,
     POWER_CALLIGRAPHY_INPUT_FACE1,
+};
+
+
+// Engine Types:
+struct PowerCalligraphyEngineData {
+    u8 pad[0x218];
+};
+
+struct PowerCalligraphyCue {
+    /* add fields here */
+};
+
+struct PowerCalligraphyBrushMotion {
+    s8 x;
+    s8 y;
+    s8 playback;
 };
 
 

--- a/include/engines/quiz_show.h
+++ b/include/engines/quiz_show.h
@@ -5,22 +5,6 @@
 
 #include "games/quiz_show/graphics/quiz_show_graphics.h"
 
-// Engine Types:
-struct QuizShowEngineData {
-    u8 pad[0x58];
-};
-
-struct QuizShowCue {
-    /* add fields here */
-};
-
-struct QuizShowScriptTable {
-    struct Beatscript *scriptA;
-    struct Beatscript *scriptB;
-    struct QuizShowScriptTable **scriptTable;
-};
-
-
 // Engine Macros/Enums:
 enum QuizShowVersionsEnum {
     QUIZ_SHOW_VER_0,
@@ -35,6 +19,22 @@ enum QuizShowCharactersEnum {
 enum QuizShowHostArmsEnum {
     QUIZ_SHOW_HOST_ARM_RIGHT,
     QUIZ_SHOW_HOST_ARM_LEFT
+};
+
+
+// Engine Types:
+struct QuizShowEngineData {
+    u8 pad[0x58];
+};
+
+struct QuizShowCue {
+    /* add fields here */
+};
+
+struct QuizShowScriptTable {
+    struct Beatscript *scriptA;
+    struct Beatscript *scriptB;
+    struct QuizShowScriptTable **scriptTable;
 };
 
 

--- a/include/engines/rap_men.h
+++ b/include/engines/rap_men.h
@@ -5,24 +5,6 @@
 
 #include "games/rap_men/graphics/rap_men_graphics.h"
 
-// Engine Types:
-struct RapMenEngineData {
-    u8 version;
-    struct BitmapFontOBJ *unk4;
-    s16 rapperSprite;
-    s16 playerSprite;
-    s16 textSprite;
-    u16 rapperAnimTimer;
-    u16 playerAnimTimer;
-    u16 unusedAnimTimer;
-    u8 isTutorial;
-};
-
-struct RapMenCue {
-    u32 sound;
-};
-
-
 // Engine Macros/Enums:
 enum RapMenVersionsEnum {
     ENGINE_VER_RAP_MEN,
@@ -54,6 +36,24 @@ enum RappingAnimationsEnum {
     RAPPING_ANIM_SAIKO,
     RAPPING_ANIM_RECOIL,
     RAPPING_ANIM_HONTO
+};
+
+
+// Engine Types:
+struct RapMenEngineData {
+    u8 version;
+    struct BitmapFontOBJ *unk4;
+    s16 rapperSprite;
+    s16 playerSprite;
+    s16 textSprite;
+    u16 rapperAnimTimer;
+    u16 playerAnimTimer;
+    u16 unusedAnimTimer;
+    u8 isTutorial;
+};
+
+struct RapMenCue {
+    u32 sound;
 };
 
 

--- a/include/engines/rhythm_toys.h
+++ b/include/engines/rhythm_toys.h
@@ -6,28 +6,6 @@
 
 #include "games/rhythm_toys/graphics/rhythm_toys_graphics.h"
 
-// Engine Types:
-struct RhythmToysEngineData {
-    u8 pad[0x384];
-};
-
-struct RhythmToysCue {
-    /* add fields here */
-};
-
-struct RhythmToysDemo {
-    u16 button;
-    u16 deltaTime;
-};
-
-struct RhythmToysSpriteData {
-    struct Animation *anim;
-    struct Vector2 *vec2;
-};
-
-typedef void (*RhythmToysPlayFunc)(u32 button);
-
-
 // Engine Macros/Enums:
 enum RhythmToysVersionsEnum {
     ENGINE_VER_CAT_MACHINE_1,
@@ -69,6 +47,28 @@ enum RhythmToysDemoButtonsEnum {
 };
 
 #define END_OF_RHYTHM_TOYS_DEMO { RHYTHM_TOYS_DEMO_STOP, 0x00 }
+
+
+// Engine Types:
+struct RhythmToysEngineData {
+    u8 pad[0x384];
+};
+
+struct RhythmToysCue {
+    /* add fields here */
+};
+
+struct RhythmToysDemo {
+    u16 button;
+    u16 deltaTime;
+};
+
+struct RhythmToysSpriteData {
+    struct Animation *anim;
+    struct Vector2 *vec2;
+};
+
+typedef void (*RhythmToysPlayFunc)(u32 button);
 
 
 // Engine Definition Data:

--- a/include/engines/rhythm_tweezers.h
+++ b/include/engines/rhythm_tweezers.h
@@ -5,6 +5,25 @@
 
 #include "games/rhythm_tweezers/graphics/rhythm_tweezers_graphics.h"
 
+// Engine Macros/Enums:
+#define RHYTHM_TWEEZERS_FALLING_HAIR_AMOUNT 5
+
+enum RhythmTweezersHeldHairsEnum {
+    TWEEZERS_HELD_HAIR_NONE,
+    TWEEZERS_HELD_HAIR_FULL,
+    TWEEZERS_HELD_HAIR_BARELY
+};
+
+enum RhythmTweezersVegetableTypesEnum {
+    VEGETABLE_TYPE_ONION,
+    VEGETABLE_TYPE_TURNIP,
+    VEGETABLE_TYPE_POTATO
+};
+
+#define RT_VEGETABLE_BG_MAP_L *(u32 *)(VRAMBase + 0xF000) // VRAM BG Map for vegetable textures (left).
+#define RT_VEGETABLE_BG_MAP_R *(u32 *)(VRAMBase + 0xF800) // VRAM BG Map for vegetable textures (right).
+
+
 // Engine Types:
 struct RhythmTweezersEngineData {
     u8 version; // Value:   Version { 0..2 = Rhythm Tweezers; 3..5 = Rhythm Tweezers 2 }
@@ -26,7 +45,7 @@ struct RhythmTweezersEngineData {
         u32 fallSpeed;      // Value: Vertical Velocity
         s16 rotation;       // Value:   Rotation
         u16 rotationSpeed;  // Value:   Randomised Rotation Speed ( agb_random(0x1f) - 0xf )
-    } fallingHairs[5];
+    } fallingHairs[RHYTHM_TWEEZERS_FALLING_HAIR_AMOUNT];
     struct RhythmTweezersVegetable {
         s16 spriteCurrent;  // Sprite:  Current Vegetable Face
         s16 spriteNext;     // Sprite:  Upcoming Vegetable Face
@@ -65,23 +84,6 @@ struct RhythmTweezersCue {
     u16 pullTime; // Current pulling time.
     u16 pullTarget; // Target pulling time.
 };
-
-
-// Engine Macros/Enums:
-enum RhythmTweezersHeldHairsEnum {
-    TWEEZERS_HELD_HAIR_NONE,
-    TWEEZERS_HELD_HAIR_FULL,
-    TWEEZERS_HELD_HAIR_BARELY
-};
-
-enum RhythmTweezersVegetableTypesEnum {
-    VEGETABLE_TYPE_ONION,
-    VEGETABLE_TYPE_TURNIP,
-    VEGETABLE_TYPE_POTATO
-};
-
-#define RT_VEGETABLE_BG_MAP_L *(u32 *)(VRAMBase + 0xF000) // VRAM BG Map for vegetable textures (left).
-#define RT_VEGETABLE_BG_MAP_R *(u32 *)(VRAMBase + 0xF800) // VRAM BG Map for vegetable textures (right).
 
 
 // Engine Definition Data:

--- a/include/engines/samurai_slice.h
+++ b/include/engines/samurai_slice.h
@@ -5,6 +5,13 @@
 
 #include "games/samurai_slice/graphics/samurai_slice_graphics.h"
 
+// Engine Macros/Enums:
+enum SamuraiSliceVersionsEnum {
+    SAMURAI_SLICE_VER_0,
+    SAMURAI_SLICE_VER_REMIX
+};
+
+
 // Engine Types:
 struct SamuraiSliceEngineData {
     u8 pad[0x1e4];
@@ -18,13 +25,6 @@ struct SamuraiSlice_0805a5d4 {
     struct Animation *anim;
     u32 unk4;
     u32 unk8;
-};
-
-
-// Engine Macros/Enums:
-enum SamuraiSliceVersionsEnum {
-    SAMURAI_SLICE_VER_0,
-    SAMURAI_SLICE_VER_REMIX
 };
 
 

--- a/include/engines/showtime.h
+++ b/include/engines/showtime.h
@@ -6,6 +6,9 @@
 #include "games/showtime/graphics/showtime_graphics.h"
 
 // Engine Macros/Enums:
+#define SHOWTIME_SUB_AMOUNT 2
+#define SHOWTIME_SUB2_AMOUNT 8
+
 enum ShowtimeVersionsEnum {
     SHOWTIME_VER_0,
     SHOWTIME_VER_REMIX_3
@@ -20,7 +23,7 @@ struct ShowtimeEngineData {
         s16 sprite;
         u32 unk4;
         s32 unk8;
-    } unk8[2];
+    } unk8[SHOWTIME_SUB_AMOUNT];
     u32 pad20;
     struct ShowtimeEngineData_sub1 {
         u32 unk0;

--- a/include/engines/showtime.h
+++ b/include/engines/showtime.h
@@ -5,6 +5,13 @@
 
 #include "games/showtime/graphics/showtime_graphics.h"
 
+// Engine Macros/Enums:
+enum ShowtimeVersionsEnum {
+    SHOWTIME_VER_0,
+    SHOWTIME_VER_REMIX_3
+};
+
+
 struct ShowtimeEngineData {
     struct BitmapFontOBJ *unk0;
     u16 unk4;
@@ -46,13 +53,6 @@ struct ShowtimeEngineData {
 struct ShowtimeCue {
     u32 unk0;
     u32 unk4;
-};
-
-
-// Engine Macros/Enums:
-enum ShowtimeVersionsEnum {
-    SHOWTIME_VER_0,
-    SHOWTIME_VER_REMIX_3
 };
 
 

--- a/include/engines/sick_beats.h
+++ b/include/engines/sick_beats.h
@@ -5,95 +5,10 @@
 
 #include "games/sick_beats/graphics/sick_beats_graphics.h"
 
-// Engine Types:
-
-struct SickBeatsPath {
-    /* 00 */ u8 command;
-    /* 01 */ u8 arg;
-    /* 02 */ u16 rest;
-};
-
-
-struct SickBeatsEngineData {
-    u8 version;
-    struct SickBeatsYellowMicrobe {
-        s16 sprite;
-        u8 state;
-        u8 isHurt;
-        u16 eventTimer;
-    } yellowMicrobe;
-    struct SickBeatsForks {
-        s16 launcher;
-        struct AffineSprite *spriteUp, *spriteDown, *spriteLeft, *spriteRight;
-        u16 counterUp, counterDown, counterLeft, counterRight;
-    } forks;
-    struct SickBeatsVirus {
-        u8 exists[0x100]; // Whether a virus exists
-        s8 state;
-        s8 current;
-        u16 spawnedCounter;
-        u8 hitsRequired1;
-        u8 virusCuePalette;
-        u8 hitsRequired;
-        u8 virusPalette;
-        struct SickBeatsVirusData {
-            struct SickBeatsPath *path;
-            u8 hitsRequired;
-            u8 palette;
-            s16 virusID;
-            s32 rest;
-        } virusData[16];
-    } virus;
-    s8 doctorCurrentState;
-    s8 doctorNextState;
-    u8 unk1F2;
-    u16 doctorBeatCounter;
-    s16 doctorSprite;
-    s16 radioSprite;
-    struct Beatscript *gameOverBeatscript;
-    u16 gameOverCounter;
-    u8 microbeWasHurt; // Whether the microbe was hurt (at least once)
-    struct SickBeatsScoreCounter {
-        u16 counterSprite;
-        s16 digitSprite[4];
-        u16 value;
-    } scoreCounters[2];
-    u8 unk21C;
-    s16 particleSprites[20];
-    u16 particleCounters[20];
-    u8 particleCurrent;
-    u8 particlePitch;
-    u8 particleCels; // Amount of cels in a particle anim
-};
-
-struct SickBeatsCue {
-    u32 unk0_b0:4;
-    u32 isVirusHitOnce:1; // Whether the virus has been hit, at least once
-    u32 unk0_b5:1;
-    u32 virusState:5;
-    u32 unk0_b12:19; 
-    u8 currentVirus;
-    struct AffineSprite *virusSprite;
-    u32 padC[(0x2c-0xc)/4];
-    u8 unk2C;
-    u8 unk2D;
-    u8 hitAmount;
-    u8 virusPalette;
-};
-
-struct VirusAction {
-    struct Animation *anim;
-    s16 x;
-    s16 y;
-    s8 playbackArg1;
-    s8 playbackArg2;
-    u16 playbackArg3;
-    u32 unkC;
-    s16 rotation;
-};
-
-
 // Engine Macros/Enums:
+#define SICK_BEATS_PARTICLE_AMOUNT 20
+#define SICK_BEATS_VIRUS_AMOUNT 16
+
 enum SickBeatsVersionsEnum {
     ENGINE_VER_SICK_BEATS,
     ENGINE_VER_SICK_BEATS_ENDLESS
@@ -136,8 +51,95 @@ enum SickBeatsVirusStatesEnum {
     SICK_BEATS_VIRUS_STATE_RIGHT_DASH_INVULN,
     SICK_BEATS_VIRUS_STATE_ATTACK_MICROBE,
     SICK_BEATS_VIRUS_STATE_INVALID = -1
-
 };
+
+
+// Engine Types:
+
+struct SickBeatsPath {
+    /* 00 */ u8 command;
+    /* 01 */ u8 arg;
+    /* 02 */ u16 rest;
+};
+
+struct SickBeatsEngineData {
+    u8 version;
+    struct SickBeatsYellowMicrobe {
+        s16 sprite;
+        u8 state;
+        u8 isHurt;
+        u16 eventTimer;
+    } yellowMicrobe;
+    struct SickBeatsForks {
+        s16 launcher;
+        struct AffineSprite *spriteUp, *spriteDown, *spriteLeft, *spriteRight;
+        u16 counterUp, counterDown, counterLeft, counterRight;
+    } forks;
+    struct SickBeatsVirus {
+        u8 exists[0x100]; // Whether a virus exists
+        s8 state;
+        s8 current;
+        u16 spawnedCounter;
+        u8 hitsRequired1;
+        u8 virusCuePalette;
+        u8 hitsRequired;
+        u8 virusPalette;
+        struct SickBeatsVirusData {
+            struct SickBeatsPath *path;
+            u8 hitsRequired;
+            u8 palette;
+            s16 virusID;
+            s32 rest;
+        } virusData[SICK_BEATS_VIRUS_AMOUNT];
+    } virus;
+    s8 doctorCurrentState;
+    s8 doctorNextState;
+    u8 unk1F2;
+    u16 doctorBeatCounter;
+    s16 doctorSprite;
+    s16 radioSprite;
+    struct Beatscript *gameOverBeatscript;
+    u16 gameOverCounter;
+    u8 microbeWasHurt; // Whether the microbe was hurt (at least once)
+    struct SickBeatsScoreCounter {
+        u16 counterSprite;
+        s16 digitSprite[4];
+        u16 value;
+    } scoreCounters[2];
+    u8 unk21C;
+    s16 particleSprites[SICK_BEATS_PARTICLE_AMOUNT];
+    u16 particleCounters[SICK_BEATS_PARTICLE_AMOUNT];
+    u8 particleCurrent;
+    u8 particlePitch;
+    u8 particleCels; // Amount of cels in a particle anim
+};
+
+struct SickBeatsCue {
+    u32 unk0_b0:4;
+    u32 isVirusHitOnce:1; // Whether the virus has been hit, at least once
+    u32 unk0_b5:1;
+    u32 virusState:5;
+    u32 unk0_b12:19; 
+    u8 currentVirus;
+    struct AffineSprite *virusSprite;
+    u32 padC[(0x2c-0xc)/4];
+    u8 unk2C;
+    u8 unk2D;
+    u8 hitAmount;
+    u8 virusPalette;
+};
+
+struct VirusAction {
+    struct Animation *anim;
+    s16 x;
+    s16 y;
+    s8 playbackArg1;
+    s8 playbackArg2;
+    u16 playbackArg3;
+    u32 unkC;
+    s16 rotation;
+};
+
 
 // Engine Definition Data:
 extern s16 sick_beats_particle_sfx_pitch[];

--- a/include/engines/sneaky_spirits.h
+++ b/include/engines/sneaky_spirits.h
@@ -5,14 +5,25 @@
 
 #include "games/sneaky_spirits/graphics/sneaky_spirits_graphics.h"
 
+// Engine Macros/Enums:
+#define SNEAKY_SPIRITS_RAIN_DROP_AMOUNT 30
+#define SNEAKY_SPIRITS_RAIN_SPLASH_AMOUNT 20
+
+enum SneakySpiritsVersionsEnum {
+    SNEAKY_SPIRITS_VERSION_1,
+    SNEAKY_SPIRITS_VERSION_REMIX,
+    SNEAKY_SPIRITS_VERSION_2
+};
+
+
 // Engine Types:
 struct SneakySpiritsEngineData {
     struct BitmapFontOBJ *unk0;  // Pointer: Font? (Related to Tutorial Text)
     u8  version;        // Value:   Version
     u8  rainSlow;       // Flag:    Slow-Motion Rain
-    s16 rainDrops[30];      // Sprite:  Raindrops
+    s16 rainDrops[SNEAKY_SPIRITS_RAIN_DROP_AMOUNT];      // Sprite: Raindrops
     u16 rainDropNext;       // Counter: Next Raindrop to Update
-    s16 rainSplashes[20];   // Sprite:  Rain Splashes
+    s16 rainSplashes[SNEAKY_SPIRITS_RAIN_SPLASH_AMOUNT]; // Sprite: Rain Splashes
     u16 rainSplashNext;     // Counter: Next Rain Splash to Update
     s16 tree;           // Sprite:  Tree
     s16 bow;            // Sprite:  Bow
@@ -43,14 +54,6 @@ struct SneakySpiritsCue {
     u32 unused20;
     u16 unused24;
     u8 disableTaunt;
-};
-
-
-// Engine Macros/Enums:
-enum SneakySpiritsVersionsEnum {
-    SNEAKY_SPIRITS_VERSION_1,
-    SNEAKY_SPIRITS_VERSION_REMIX,
-    SNEAKY_SPIRITS_VERSION_2
 };
 
 

--- a/include/engines/space_dance.h
+++ b/include/engines/space_dance.h
@@ -5,16 +5,6 @@
 
 #include "games/space_dance/graphics/space_dance_graphics.h"
 
-// Engine Types:
-struct SpaceDanceEngineData {
-    u8 pad[0x38];
-};
-
-struct SpaceDanceCue {
-    /* add fields here */
-};
-
-
 // Engine Macros/Enums:
 enum SpaceDanceVersionsEnum {
     ENGINE_VER_SPACE_DANCE,
@@ -74,6 +64,16 @@ enum SpaceGrampsAnimationsEnum {
     SPACE_GRAMPS_ANIM_DOWN_CUE,
     SPACE_GRAMPS_ANIM_SPEAK,
     SPACE_GRAMPS_ANIM_BLINK
+};
+
+
+// Engine Types:
+struct SpaceDanceEngineData {
+    u8 pad[0x38];
+};
+
+struct SpaceDanceCue {
+    /* add fields here */
 };
 
 

--- a/include/engines/spaceball.h
+++ b/include/engines/spaceball.h
@@ -5,6 +5,16 @@
 
 #include "games/spaceball/graphics/spaceball_graphics.h"
 
+// Engine Macros/Enums:
+#define SPACEBALL_STAR_AMOUNT 24
+
+enum SpaceballCueStatesEnum {
+    SPACEBALL_CUE_STATE_LAUNCH,
+    SPACEBALL_CUE_STATE_HIT,
+    SPACEBALL_CUE_STATE_BARELY
+};
+
+
 struct SpaceballEntity {
     struct AffineSprite *sprite;
     s32 x;
@@ -29,12 +39,12 @@ struct SpaceballEngineData {
     struct SpaceballEntity poofR;   // Sprite used when a spaceball is missed (right)
     struct SpaceballEntity poofL;   // Sprite used when a spaceball is missed (left)
     u16 currentStar;    // Counter: Number of Existing BG Stars
-    s16 starSprite[24];
+    s16 starSprite[SPACEBALL_STAR_AMOUNT];
     struct SpaceballStar {
         s16 x;
         s16 y;
         s16 z;
-    } stars[24];
+    } stars[SPACEBALL_STAR_AMOUNT];
     u8 totalMissed;
     u8 spaceballType;
 };
@@ -52,14 +62,6 @@ struct SpaceballCue {
     u32 xSpeed; // Used for 'Barely' arc only
     u32 ySpeed; // Used for 'Barely' arc only
     u8 missed;
-};
-
-
-// Engine Macros/Enums:
-enum SpaceballCueStatesEnum {
-    SPACEBALL_CUE_STATE_LAUNCH,
-    SPACEBALL_CUE_STATE_HIT,
-    SPACEBALL_CUE_STATE_BARELY
 };
 
 

--- a/include/engines/tap_trial.h
+++ b/include/engines/tap_trial.h
@@ -5,29 +5,6 @@
 
 #include "games/tap_trial/graphics/tap_trial_graphics.h"
 
-// Engine Types:
-struct TapTrialEngineData {
-    u8 pad[0x398];
-};
-
-struct TapTrialCue {
-    s32 unused;
-};
-
-struct TapTrialAction {
-    s8 animID;
-    s8 playbackArg1;
-    s8 playbackArg2;
-    s8 unk3;
-    s8 playbackArg3;
-    u16 playbackArg4;
-    u8 duration;
-    struct SequenceData *sfx;
-    u16 sfxVolume;
-    s16 sfxPitch;
-};
-
-
 // Engine Macros/Enums:
 enum TapTrialVersionsEnum {
     ENGINE_VER_TAP_TRIAL,
@@ -70,6 +47,29 @@ enum TapTrialAnimationsEnum {
     TAP_TRIAL_ANIM_GIRAFFE_BEDAZZLED,
     TAP_TRIAL_ANIM_GIRAFFE_NEUTRAL,
     TAP_TRIAL_ANIM_GIRAFFE_DISAPPOINTED
+};
+
+
+// Engine Types:
+struct TapTrialEngineData {
+    u8 pad[0x398];
+};
+
+struct TapTrialCue {
+    s32 unused;
+};
+
+struct TapTrialAction {
+    s8 animID;
+    s8 playbackArg1;
+    s8 playbackArg2;
+    s8 unk3;
+    s8 playbackArg3;
+    u16 playbackArg4;
+    u8 duration;
+    struct SequenceData *sfx;
+    u16 sfxVolume;
+    s16 sfxPitch;
 };
 
 

--- a/include/engines/toss_boys.h
+++ b/include/engines/toss_boys.h
@@ -6,16 +6,6 @@
 
 #include "games/toss_boys/graphics/toss_boys_graphics.h"
 
-// Engine Types:
-struct TossBoysEngineData {
-    u8 pad[0x3a4];
-};
-
-struct TossBoysCue {
-    /* add fields here */
-};
-
-
 // Engine Macros/Enums:
 enum TossBoysVersionsEnum {
     ENGINE_VER_TOSS_BOYS,
@@ -67,6 +57,16 @@ enum TossBoyActionsEnum {
     TOSS_BOY_ACTION_SUPER_PASS,
     TOSS_BOY_ACTION_CATCH,
     TOSS_BOY_ACTION_POP
+};
+
+
+// Engine Types:
+struct TossBoysEngineData {
+    u8 pad[0x3a4];
+};
+
+struct TossBoysCue {
+    /* add fields here */
 };
 
 

--- a/include/engines/tram_and_pauline.h
+++ b/include/engines/tram_and_pauline.h
@@ -5,6 +5,15 @@
 
 #include "games/tram_and_pauline/graphics/tram_pauline_graphics.h"
 
+// Engine Macros/Enums:
+enum TramPaulineVersionsEnum {
+    ENGINE_VER_TRAM_PAULINE_TUTORIAL,
+    ENGINE_VER_TRAM_PAULINE,
+    ENGINE_VER_TRAM_PAULINE_REMIX_3,
+    ENGINE_VER_TRAM_PAULINE_NO_CURTAIN
+};
+
+
 // Engine Types:
 struct TramPaulineEngineData {
     u8 pad[0x48];
@@ -12,15 +21,6 @@ struct TramPaulineEngineData {
 
 struct TramPaulineCue {
     /* add fields here */
-};
-
-
-// Engine Macros/Enums:
-enum TramPaulineVersionsEnum {
-    ENGINE_VER_TRAM_PAULINE_TUTORIAL,
-    ENGINE_VER_TRAM_PAULINE,
-    ENGINE_VER_TRAM_PAULINE_REMIX_3,
-    ENGINE_VER_TRAM_PAULINE_NO_CURTAIN
 };
 
 

--- a/include/engines/wizards_waltz.h
+++ b/include/engines/wizards_waltz.h
@@ -5,6 +5,10 @@
 
 #include "games/wizards_waltz/graphics/wizards_waltz_graphics.h"
 
+// Engine Macros/Enums:
+#define WIZARDS_WALTZ_SPARKLE_AMOUNT 10
+
+
 // Engine Types:
 struct WizardsWaltzEntity {
     struct AffineSprite *sprite;
@@ -21,7 +25,7 @@ struct WizardsWaltzEngineData {
     u8 version;
     struct WizardsWaltzEntity wizard;
     struct WizardsWaltzEntity shadow;
-    struct WizardsWaltzEntity sparkle[10];
+    struct WizardsWaltzEntity sparkle[WIZARDS_WALTZ_SPARKLE_AMOUNT];
     struct WizardsWaltzEntity girl;
     s32 cyclePosition;  // Current point in cycle
     s32 cycleInterval;  // Duration of one cycle

--- a/include/global.h
+++ b/include/global.h
@@ -32,7 +32,7 @@ typedef s32 s24_8;
 #define FIXED_TO_INT(x) ((s32)((x) >> 8))
 #define FIXED_POINT_MUL(a, b) (((a) * (b)) >> 8)
 
-#define ARRAY_COUNT(a) (size_t)(sizeof(a))/sizeof((a)[0])
+#define ARRAY_COUNT(a) (s32)(sizeof(a))/sizeof((a)[0])
 
 #include "gba/gba.h"
 #include "types.h"

--- a/src/bitmap_font.c
+++ b/src/bitmap_font.c
@@ -670,7 +670,7 @@ struct WobblyPrintedTextAnim *bmp_font_obj_print_wobbly(struct BitmapFontOBJ *te
     newAnim = mem_heap_alloc_id(textObj->memID, size);
     newCel = newAnim->oam;
 
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < (ARRAY_COUNT(newAnim->frames) - 1); i++) {
         (newAnim->frames + i)->cel = newCel;
         (newAnim->frames + i)->duration = frameDuration;
         newCel[0] = count;

--- a/src/code_08001360.c
+++ b/src/code_08001360.c
@@ -647,7 +647,7 @@ void func_08002b10(struct GfxTableLoader *info) {
             case COMPRESSION_LEVEL_RLE:
                 if (info->decodingRLE) {
                     D_030053b0 = TRUE;
-                    for (i = 0; i < 8; i++) {
+                    for (i = 0; i < ARRAY_COUNT(info->rleSaveState); i++) {
                         D_03005390[i] = info->rleSaveState[i];
                     }
                     size = func_08003ea4();
@@ -662,7 +662,7 @@ void func_08002b10(struct GfxTableLoader *info) {
                 }
                 if (D_030053b0) {
                     info->decodingRLE = TRUE;
-                    for (i = 0; i < 8; i++) {
+                    for (i = 0; i < ARRAY_COUNT(info->rleSaveState); i++) {
                         info->rleSaveState[i] = D_03005390[i];
                     }
                     D_030053b0 = FALSE;

--- a/src/code_0800b778.c
+++ b/src/code_0800b778.c
@@ -701,7 +701,7 @@ void func_0800dfc0(void) {
 }
 
 
-// Get previous thread's task ID
+// Get current thread's task ID
 s32 func_0800dfc4(void) {
     struct BeatscriptThread *thread = &D_030053c0.threads[get_current_mem_id()] - 1;
 

--- a/src/code_0800b778.c
+++ b/src/code_0800b778.c
@@ -701,7 +701,7 @@ void func_0800dfc0(void) {
 }
 
 
-// a very broken (and unused) function
+// Get previous thread's task ID
 s32 func_0800dfc4(void) {
     struct BeatscriptThread *thread = &D_030053c0.threads[get_current_mem_id()] - 1;
 

--- a/src/code_0800b778.c
+++ b/src/code_0800b778.c
@@ -40,7 +40,7 @@ void start_beatscript_scene(u32 memID) {
     D_030053c0.musicTrkTargets = 0;
     D_030053c0.musicKey = 0;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_030053c0.threads); i++) {
         D_030053c0.threads[i].active = FALSE;
     }
 
@@ -63,12 +63,12 @@ void set_beatscript_subscenes(const struct SubScene **subScenes) {
     D_030053c0.exitLoopNextUpdate = FALSE;
     D_030053c0.runningTime = 0;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_030053c0.threads); i++) {
         D_030053c0.threads[i].active = FALSE;
         D_030053c0.threads[i].unk0_b7 = FALSE;
     }
 
-    for (i = 0; (i < 2) && (subScenes[i] != NULL); i++) {
+    for (i = 0; (i < ARRAY_COUNT(D_030053c0.threads)) && (subScenes[i] != NULL); i++) {
         D_030053c0.currentThread = i;
         set_current_mem_id(D_030053c0.currentThread + 1);
         D_030053c0.threads[i].active = TRUE;
@@ -95,7 +95,7 @@ void update_paused_beatscript_scene(void) {
     const struct SubScene *subScene;
     u32 i;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_030053c0.threads); i++) {
         D_030053c0.currentThread = i;
         set_current_mem_id(D_030053c0.currentThread + 1);
 
@@ -134,7 +134,7 @@ void update_active_beatscript_scene(void) {
         }
     }
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_030053c0.threads); i++) {
         D_030053c0.currentThread = i;
         set_current_mem_id(D_030053c0.currentThread + 1);
         thread = &D_030053c0.threads[i];
@@ -189,7 +189,7 @@ void update_active_beatscript_scene(void) {
     }
 
     if (!D_030053c0.paused) {
-        for (i = 0; i < 2; i++) {
+        for (i = 0; i < ARRAY_COUNT(D_030053c0.threads); i++) {
             D_030053c0.threads[i].timeUntilNext -= D_030053c0.deltaTime;
         }
         D_030053c0.runningTime += D_030053c0.deltaTime;
@@ -201,7 +201,7 @@ void update_active_beatscript_scene(void) {
 s32 beatscript_scene_is_inactive(void) {
     u32 i;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_030053c0.threads); i++) {
         if (D_030053c0.threads[i].active) {
             return FALSE;
         }
@@ -286,7 +286,7 @@ void stop_beatscript_scene(void) {
     const struct SubScene *subScene;
     u32 i, i2;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_030053c0.threads); i++) {
         D_030053c0.currentThread = i;
         set_current_mem_id(D_030053c0.currentThread + 1);
         thread = &D_030053c0.threads[i];
@@ -703,14 +703,9 @@ void func_0800dfc0(void) {
 
 // a very broken (and unused) function
 s32 func_0800dfc4(void) {
-    void *r0;
+    struct BeatscriptThread *thread = &D_030053c0.threads[get_current_mem_id()] - 1;
 
-    r0 = (s32 *)((get_current_mem_id() * 0x9c));
-    r0 += ((s32)&D_030053c0 - 0x74); // ((s32)&D_03004b10 + 0x83c)
-    r0 += 0x98;
-    return *((s32 *)r0);
-
-    // return *((s32 *)&D_030053c0.threads[get_current_mem_id()]-1);
+    return thread->currentTaskID;
 }
 
 

--- a/src/code_0800b778.h
+++ b/src/code_0800b778.h
@@ -110,7 +110,7 @@ extern struct BitmapFontOBJ *func_0800c660(u16, u8);
 // extern ? func_0800cb28(?); // BEATSCRIPT - Update Stream
 extern void func_0800dfbc(void); // Stub
 extern void func_0800dfc0(void); // Stub
-extern s32 func_0800dfc4(void); // a very broken (and unused) function
+extern s32 func_0800dfc4(void); // Get previous thread's task ID
 extern void func_0800dfe0(void); // Stub
 extern void func_0800dfe4(void); // Stub
 extern void func_0800dfe8(void); // Stub

--- a/src/code_0800b778.h
+++ b/src/code_0800b778.h
@@ -110,7 +110,7 @@ extern struct BitmapFontOBJ *func_0800c660(u16, u8);
 // extern ? func_0800cb28(?); // BEATSCRIPT - Update Stream
 extern void func_0800dfbc(void); // Stub
 extern void func_0800dfc0(void); // Stub
-extern s32 func_0800dfc4(void); // Get previous thread's task ID
+extern s32 func_0800dfc4(void); // Get current thread's task ID
 extern void func_0800dfe0(void); // Stub
 extern void func_0800dfe4(void); // Stub
 extern void func_0800dfe8(void); // Stub

--- a/src/code_080102d0.c
+++ b/src/code_080102d0.c
@@ -59,11 +59,11 @@ void reset_game_save_data(void) {
     }
     data->campaignState = CAMPAIGN_STATE_INACTIVE;
 
-    for (i = 0; i < 20; i++) {
+    for (i = 0; i < ARRAY_COUNT(data->readingMaterialUnlocked); i++) {
         data->readingMaterialUnlocked[i] = FALSE;
     }
 
-    for (i = 0; i < 15; i++) {
+    for (i = 0; i < ARRAY_COUNT(data->drumKitsUnlocked); i++) {
         data->drumKitsUnlocked[i] = FALSE;
     }
 
@@ -72,7 +72,7 @@ void reset_game_save_data(void) {
     data->unk290 = 2;
     data->unk291 = 0;
 
-    for (i = 0; i < 16; i++) {
+    for (i = 0; i < ARRAY_COUNT(data->unk294); i++) {
         data->unk294[i] = 0;
     }
 

--- a/src/engines/bon_odori.c
+++ b/src/engines/bon_odori.c
@@ -156,7 +156,7 @@ void bon_odori_engine_start(u32 ver) {
     D_03004b10.BLDMOD = (BLDMOD_BG0_SRC | BLDMOD_BLEND_MODE(BLEND_MODE_ALPHA) | BLDMOD_SPRITES_TGT);
     D_03004b10.COLEV = (COLEV_SRC_PIXEL(0x10) | COLEV_TGT_PIXEL(0x10));
 
-    for (i = 0; i < ARRAY_COUNT(gBonOdori->lyrics); i++) {
+    for (i = 0; i < BON_ODORI_LYRIC_AMOUNT; i++) {
         gBonOdori->lyrics[i].textSprite = -1;
     }
 

--- a/src/engines/bon_odori.c
+++ b/src/engines/bon_odori.c
@@ -40,9 +40,9 @@ void bon_odori_init_donpans(void) {
     y = 120;
     z = 0x4800;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < BON_ODORI_DONPAN_AMOUNT; i++) {
         anim = bon_odori_get_donpan_anim(DONPAN_ANIM_BEAT, i);
-        gBonOdori->donpanSprites[i] = func_0804d160(D_03005380, anim, 0x7f, x, y, z, 1, 0x7f, 0);;
+        gBonOdori->donpanSprites[i] = func_0804d160(D_03005380, anim, 0x7f, x, y, z, 1, 0x7f, 0);
         gBonOdori->donpanAnimTimers[i] = 0;
         x += 53;
     }
@@ -71,7 +71,7 @@ void bon_odori_set_donpan_anim(u32 animation, u32 donpan) {
 void bon_odori_set_cpu_donpan_anim(u32 anim) {
     u32 i;
 
-    for (i = 0; i < 3; i++) {
+    for (i = 0; i < (BON_ODORI_DONPAN_AMOUNT - 1); i++) {
         bon_odori_set_donpan_anim(anim, i);
     }
 }
@@ -94,7 +94,7 @@ void bon_odori_set_all_donpan_anim(u32 anim) {
 void bon_odori_set_cpu_donpan_anim_timer(u32 duration) {
     u32 i;
 
-    for (i = 0; i < 3; i++) {
+    for (i = 0; i < (BON_ODORI_DONPAN_AMOUNT - 1); i++) {
         gBonOdori->donpanAnimTimers[i] = beats_to_ticks(duration);
     }
 }
@@ -104,7 +104,7 @@ void bon_odori_set_cpu_donpan_anim_timer(u32 duration) {
 void bon_odori_update_donpans(void) {
     u32 i;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < BON_ODORI_DONPAN_AMOUNT; i++) {
         if (gBonOdori->donpanAnimTimers[i] != 0) {
             gBonOdori->donpanAnimTimers[i]--;
         }
@@ -156,7 +156,7 @@ void bon_odori_engine_start(u32 ver) {
     D_03004b10.BLDMOD = (BLDMOD_BG0_SRC | BLDMOD_BLEND_MODE(BLEND_MODE_ALPHA) | BLDMOD_SPRITES_TGT);
     D_03004b10.COLEV = (COLEV_SRC_PIXEL(0x10) | COLEV_TGT_PIXEL(0x10));
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < ARRAY_COUNT(gBonOdori->lyrics); i++) {
         gBonOdori->lyrics[i].textSprite = -1;
     }
 
@@ -441,7 +441,7 @@ void bon_odori_common_beat_animation(u32 arg) {
     struct Animation *anim;
     u32 i;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < BON_ODORI_DONPAN_AMOUNT; i++) {
         if (gBonOdori->donpanAnimTimers[i] == 0) {
             anim = bon_odori_get_donpan_anim(DONPAN_ANIM_BEAT, i);
             if ((i < 3) && (gBonOdori->donpanEmoteTimer != 0)) {

--- a/src/engines/bon_odori.c
+++ b/src/engines/bon_odori.c
@@ -444,7 +444,7 @@ void bon_odori_common_beat_animation(u32 arg) {
     for (i = 0; i < BON_ODORI_DONPAN_AMOUNT; i++) {
         if (gBonOdori->donpanAnimTimers[i] == 0) {
             anim = bon_odori_get_donpan_anim(DONPAN_ANIM_BEAT, i);
-            if ((i < 3) && (gBonOdori->donpanEmoteTimer != 0)) {
+            if ((i < (BON_ODORI_DONPAN_AMOUNT - 1)) && (gBonOdori->donpanEmoteTimer != 0)) {
                 anim = bon_odori_get_donpan_anim(gBonOdori->donpanEmoteAnim, i);
             }
             func_0804d8f8(D_03005380, gBonOdori->donpanSprites[i], anim, 0, 1, 0x7f, 0);

--- a/src/engines/drum_studio.c
+++ b/src/engines/drum_studio.c
@@ -254,7 +254,7 @@ void drum_lessons_init_lesson(void) {
     gDrumStudio->unk563 = 0;
     gDrumStudio->unk564 = 0;
 
-    for (i = 0; i < ARRAY_COUNT(gDrumStudio->accuracyLightSprites); i++) {
+    for (i = 0; i < DRUM_STUDIO_ACCURACY_LIGHTS_AMOUNT; i++) {
         gDrumStudio->accuracyLightSprites[i] = func_0804d160(D_03005380, drum_lessons_accuracy_light_anim[i], 0x7f, drum_lessons_accuracy_light_positions[i].x, drum_lessons_accuracy_light_positions[i].y, 0x4f00, 1, 0x7f, 0x8002);
         func_0804d890(D_03005380, gDrumStudio->accuracyLightSprites[i], 640);
     }
@@ -1189,7 +1189,7 @@ void drum_studio_flash_accuracy_meter(void) {
         timingOffset += 1;
     }
 
-    timingOffset = clamp_int32(timingOffset + 3, 0, 6);
+    timingOffset = clamp_int32(timingOffset + 3, 0, DRUM_STUDIO_ACCURACY_LIGHTS_AMOUNT - 1);
     func_0804cebc(D_03005380, gDrumStudio->accuracyLightSprites[timingOffset], 0);
     func_0804d770(D_03005380, gDrumStudio->accuracyLightSprites[timingOffset], TRUE);
 }

--- a/src/engines/drum_studio.c
+++ b/src/engines/drum_studio.c
@@ -254,7 +254,7 @@ void drum_lessons_init_lesson(void) {
     gDrumStudio->unk563 = 0;
     gDrumStudio->unk564 = 0;
 
-    for (i = 0; i < 7; i++) {
+    for (i = 0; i < ARRAY_COUNT(gDrumStudio->accuracyLightSprites); i++) {
         gDrumStudio->accuracyLightSprites[i] = func_0804d160(D_03005380, drum_lessons_accuracy_light_anim[i], 0x7f, drum_lessons_accuracy_light_positions[i].x, drum_lessons_accuracy_light_positions[i].y, 0x4f00, 1, 0x7f, 0x8002);
         func_0804d890(D_03005380, gDrumStudio->accuracyLightSprites[i], 640);
     }

--- a/src/engines/fireworks.c
+++ b/src/engines/fireworks.c
@@ -331,7 +331,9 @@ void fireworks_create_explosion(u8 pattern, s32 x, s32 y) {
         gFireworks->particles[i].y = y + gFireworks->particles[i].velY;
         gFireworks->particles[i].colour = colour;
 
-        if (pattern <= 2) { // STANDARD FIREWORK PATTERN
+        if ((pattern == FIREWORKS_PATTERN_L3) ||
+            (pattern == FIREWORKS_PATTERN_C3) ||
+            (pattern == FIREWORKS_PATTERN_R3)) { // STANDARD FIREWORK PATTERN
             if (i < (min + 8)) {
                 gFireworks->particles[i].colour = fireworks_particle_combinations[colour].inner;
             }

--- a/src/engines/fireworks.c
+++ b/src/engines/fireworks.c
@@ -81,7 +81,7 @@ void fireworks_engine_start(u32 version) {
     gFireworks->patternMode = FIREWORKS_PATTERN_MODE_0;
     gFireworks->patternDefault = FIREWORKS_PATTERN_L3;
 
-    for (i = 0; i < ARRAY_COUNT(gFireworks->particles); i++) {
+    for (i = 0; i < FIREWORKS_PARTICLE_AMOUNT; i++) {
         gFireworks->particles[i].sprite = func_0804d160(D_03005380, anim_fireworks_particle_red, 0, 0, 0, 0x801, 0, 0, 0);
         gFireworks->particles[i].active = FALSE;
         func_0804d770(D_03005380, gFireworks->particles[i].sprite, FALSE);
@@ -141,7 +141,7 @@ void fireworks_set_pattern(u32 pattern) {
 void fireworks_update_explosion(void) {
     u8 i;
 
-    for (i = 0; i < ARRAY_COUNT(gFireworks->particles); i++) {
+    for (i = 0; i < FIREWORKS_PARTICLE_AMOUNT; i++) {
         if (gFireworks->particles[i].active) {
             gFireworks->particles[i].x += gFireworks->particles[i].velX;
             gFireworks->particles[i].velX -= gFireworks->particles[i].velX / 32;

--- a/src/engines/fireworks.c
+++ b/src/engines/fireworks.c
@@ -81,7 +81,7 @@ void fireworks_engine_start(u32 version) {
     gFireworks->patternMode = FIREWORKS_PATTERN_MODE_0;
     gFireworks->patternDefault = FIREWORKS_PATTERN_L3;
 
-    for (i = 0; i < 72; i++) {
+    for (i = 0; i < ARRAY_COUNT(gFireworks->particles); i++) {
         gFireworks->particles[i].sprite = func_0804d160(D_03005380, anim_fireworks_particle_red, 0, 0, 0, 0x801, 0, 0, 0);
         gFireworks->particles[i].active = FALSE;
         func_0804d770(D_03005380, gFireworks->particles[i].sprite, FALSE);
@@ -141,7 +141,7 @@ void fireworks_set_pattern(u32 pattern) {
 void fireworks_update_explosion(void) {
     u8 i;
 
-    for (i = 0; i < 72; i++) {
+    for (i = 0; i < ARRAY_COUNT(gFireworks->particles); i++) {
         if (gFireworks->particles[i].active) {
             gFireworks->particles[i].x += gFireworks->particles[i].velX;
             gFireworks->particles[i].velX -= gFireworks->particles[i].velX / 32;

--- a/src/engines/karate_man.c
+++ b/src/engines/karate_man.c
@@ -426,7 +426,7 @@ void karate_cue_hit(struct Cue *cue, struct KarateManCue *data) {
     }
     
     // Check if Flow is more than 2 or if Version is 2 ("Serious Mode")
-    if ((gKarateMan->flowLevel > 2)) {
+    if (gKarateMan->flowLevel > 2) {
         isHigh = TRUE;
     }
 

--- a/src/engines/night_walk.c
+++ b/src/engines/night_walk.c
@@ -278,7 +278,7 @@ s32 night_walk_scroll_stars(void) {
     hOffset = INT_TO_FIXED(-0.5);
     vOffset = gNightWalk->starsVOffset;
 
-    for (i = 0; i < 32; i++) {
+    for (i = 0; i < ARRAY_COUNT(gNightWalk->stars); i++) {
         star = &gNightWalk->stars[i];
         star->x += hOffset;
         if (star->x < INT_TO_FIXED(-8.0)) {
@@ -375,7 +375,7 @@ void night_walk_clear_all_stars(void) {
     struct NightWalkStar *star;
     u32 i;
 
-    for (i = 0; i < 32; i++) {
+    for (i = 0; i < ARRAY_COUNT(gNightWalk->stars); i++) {
         star = &gNightWalk->stars[i];
         func_0804d8f8(D_03005380, star->sprite, anim_night_walk_star_disappear, 0, 1, 0, 3);
     }
@@ -405,7 +405,7 @@ void func_0802a970(void) {
 void reset_drumtech_seq(void) {
     u32 i;
 
-    for (i = 0; i < 100; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_03001568->drumSequence); i++) {
         D_03001568->drumSequence[i].deltaTime = 0;
     }
 }
@@ -418,7 +418,7 @@ void init_drumtech(struct DrumTechController *data) {
     D_03001568 = data;
     D_03001568->drumBank = drumtech_drum_bank;
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_03001568->soundTimers); i++) {
         D_03001568->soundTimers[i] = 0;
     }
 
@@ -439,7 +439,7 @@ void init_drumtech(struct DrumTechController *data) {
 void update_drumtech_timers(void) {
     u32 i;
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_03001568->soundTimers); i++) {
         if (D_03001568->soundTimers[i] > 0) {
             if (--D_03001568->soundTimers[i] == 0) {
                 stop_soundplayer(D_08aa4460[i].soundPlayer);
@@ -454,7 +454,7 @@ void update_drumtech_seq(void) {
     struct DrumTechNote *note;
     u32 i;
 
-    for (i = 0; i < 100; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_03001568->drumSequence); i++) {
         note = &D_03001568->drumSequence[i];
 
         if (note->deltaTime > 0) {
@@ -475,7 +475,7 @@ void play_drumtech_seq(const struct DrumTechNote *sequence, s32 timingOffset, s3
 
     reset_drumtech_seq();
 
-    while ((sequence->drumID != DRUMTECH_NOTE_END_SEQ) && (i < 100)) {
+    while ((sequence->drumID != DRUMTECH_NOTE_END_SEQ) && (i < ARRAY_COUNT(D_03001568->drumSequence))) {
         delay = beats_to_ticks(ticks) + timingOffset;
         if (delay <= 0 || ticks == 0) {
             play_drumtech_note(sequence->drumID, sequence->volume, sequence->pitch);
@@ -719,7 +719,7 @@ void stop_drumtech(void) {
 
     reset_drumtech_seq();
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_03001568->soundTimers); i++) {
         if (D_03001568->soundTimers[i] != 0) {
             stop_soundplayer(D_08aa4460[i].soundPlayer);
         }

--- a/src/engines/night_walk.c
+++ b/src/engines/night_walk.c
@@ -278,7 +278,7 @@ s32 night_walk_scroll_stars(void) {
     hOffset = INT_TO_FIXED(-0.5);
     vOffset = gNightWalk->starsVOffset;
 
-    for (i = 0; i < ARRAY_COUNT(gNightWalk->stars); i++) {
+    for (i = 0; i < NIGHT_WALK_STAR_AMOUNT; i++) {
         star = &gNightWalk->stars[i];
         star->x += hOffset;
         if (star->x < INT_TO_FIXED(-8.0)) {
@@ -318,7 +318,7 @@ void night_walk_expand_star(void) {
     func_0804daa8(D_03005380, star->sprite, night_walk_finish_star_expansion, (s32)night_walk_star_anim[gNightWalk->currentStarSize + 1]);
     star->size = gNightWalk->currentStarSize + 1;
     gNightWalk->nextStar++;
-    if (gNightWalk->nextStar >= ARRAY_COUNT(gNightWalk->stars)) {
+    if (gNightWalk->nextStar >= NIGHT_WALK_STAR_AMOUNT) {
         gNightWalk->nextStar = 0;
         gNightWalk->currentStarSize++;
     }
@@ -349,7 +349,7 @@ void night_walk_shrink_star(void) {
         if (gNightWalk->currentStarSize == 0) {
             return;
         }
-        gNightWalk->nextStar = 32;
+        gNightWalk->nextStar = NIGHT_WALK_STAR_AMOUNT;
         gNightWalk->currentStarSize--;
     }
 
@@ -375,7 +375,7 @@ void night_walk_clear_all_stars(void) {
     struct NightWalkStar *star;
     u32 i;
 
-    for (i = 0; i < ARRAY_COUNT(gNightWalk->stars); i++) {
+    for (i = 0; i < NIGHT_WALK_STAR_AMOUNT; i++) {
         star = &gNightWalk->stars[i];
         func_0804d8f8(D_03005380, star->sprite, anim_night_walk_star_disappear, 0, 1, 0, 3);
     }
@@ -1114,7 +1114,7 @@ void night_walk_cue_barely(struct Cue *cue, struct NightWalkCue *info, u32 press
         if (gNightWalk->nextStar != 0) {
             night_walk_shrink_stars(gNightWalk->nextStar);
         } else if (gNightWalk->currentStarSize > 3) {
-            night_walk_shrink_stars(32);
+            night_walk_shrink_stars(NIGHT_WALK_STAR_AMOUNT);
         }
     }
     night_walk_cue_check_for_fish(info);

--- a/src/engines/night_walk.c
+++ b/src/engines/night_walk.c
@@ -318,7 +318,7 @@ void night_walk_expand_star(void) {
     func_0804daa8(D_03005380, star->sprite, night_walk_finish_star_expansion, (s32)night_walk_star_anim[gNightWalk->currentStarSize + 1]);
     star->size = gNightWalk->currentStarSize + 1;
     gNightWalk->nextStar++;
-    if (gNightWalk->nextStar >= 32) {
+    if (gNightWalk->nextStar >= ARRAY_COUNT(gNightWalk->stars)) {
         gNightWalk->nextStar = 0;
         gNightWalk->currentStarSize++;
     }

--- a/src/engines/polyrhythm.c
+++ b/src/engines/polyrhythm.c
@@ -174,7 +174,7 @@ void polyrhythm_populate_world(void) {
 
     func_0804d160(D_03005380, anim_polyrhythm_world_start, 0, 32, 112, 0x4400, 0, 0, 0);
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < POLYRHYTHM_LINE_AMOUNT; i++) {
         x = polyrhythm_lane_start_x[i];
         y = polyrhythm_lane_start_y[i];
         z = ((1 - i) * 0x400) + 0x4404;
@@ -182,7 +182,7 @@ void polyrhythm_populate_world(void) {
         func_0804d160(D_03005380, anim_polyrhythm_signs, 1 - i, 122, 111, z - 1, 0, 0, 0);
 
         block = gPolyrhythm->lanes[i];
-        for (j = 0; j < 16; j++) {
+        for (j = 0; j < POLYRHYTHM_BLOCK_AMOUNT; j++) {
             block->sprite = func_0804d160(D_03005380, anim_polyrhythm_block, 0, x, y, z, 0, 0, 0);
             block->type = BLOCK_TYPE_PLATFORM;
             block->state = BLOCK_STATE_HIDDEN;
@@ -204,7 +204,7 @@ void polyrhythm_get_pistons(u32 lane, s32 *piston1ID, s32 *piston2ID) {
     *piston2ID = -1;
     *piston1ID = -1;
 
-    for (i = 0; i < 16; i++) {
+    for (i = 0; i < POLYRHYTHM_BLOCK_AMOUNT; i++) {
         block = &gPolyrhythm->lanes[lane][i];
 
         if ((block->type == BLOCK_TYPE_PISTON_UPSIDE) || (block->type == BLOCK_TYPE_PISTON_DOWNSIDE)) {
@@ -337,7 +337,7 @@ void polyrhythm_init_rods(void) {
     struct PolyrhythmRod *rod = gPolyrhythm->rods;
     u32 i;
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < ARRAY_COUNT(gPolyrhythm->rods); i++) {
         rod->active = FALSE;
         rod->sprite = func_0804d160(D_03005380, anim_polyrhythm_rod, 0, 32, 96, 0, 1, 0, 0x8000);
         rod++;
@@ -439,7 +439,7 @@ void polyrhythm_update_rods(void) {
     s32 x, y;
     u32 z;
 
-    for (rod = gPolyrhythm->rods, i = 0; i < 8; rod++, i++) {
+    for (rod = gPolyrhythm->rods, i = 0; i < ARRAY_COUNT(gPolyrhythm->rods); rod++, i++) {
         if (rod->active) {
             switch (rod->unk0_b4) {
                 case 0:
@@ -476,7 +476,7 @@ void polyrhythm_spawn_rod(u32 lane) {
     struct PolyrhythmRod *rod = gPolyrhythm->rods;
     u32 i;
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < ARRAY_COUNT(gPolyrhythm->rods); i++) {
         if (!rod->active) {
             break;
         }

--- a/src/engines/polyrhythm.c
+++ b/src/engines/polyrhythm.c
@@ -305,7 +305,7 @@ s32 polyrhythm_get_block_height(u32 lane, s32 blockID) {
     if (blockID < 0) {
         return polyrhythm_block_heights[BLOCK_STATE_PLATFORM];
     }
-    if (blockID > 15) {
+    if (blockID > (POLYRHYTHM_BLOCK_AMOUNT - 1)) {
         return 0;
     }
 
@@ -483,7 +483,7 @@ void polyrhythm_spawn_rod(u32 lane) {
         rod++;
     }
 
-    if (i >= 8) {
+    if (i >= ARRAY_COUNT(gPolyrhythm->rods)) {
         return;
     }
 

--- a/src/engines/polyrhythm.c
+++ b/src/engines/polyrhythm.c
@@ -337,7 +337,7 @@ void polyrhythm_init_rods(void) {
     struct PolyrhythmRod *rod = gPolyrhythm->rods;
     u32 i;
 
-    for (i = 0; i < ARRAY_COUNT(gPolyrhythm->rods); i++) {
+    for (i = 0; i < POLYRHYTHM_ROD_AMOUNT; i++) {
         rod->active = FALSE;
         rod->sprite = func_0804d160(D_03005380, anim_polyrhythm_rod, 0, 32, 96, 0, 1, 0, 0x8000);
         rod++;
@@ -439,7 +439,7 @@ void polyrhythm_update_rods(void) {
     s32 x, y;
     u32 z;
 
-    for (rod = gPolyrhythm->rods, i = 0; i < ARRAY_COUNT(gPolyrhythm->rods); rod++, i++) {
+    for (rod = gPolyrhythm->rods, i = 0; i < POLYRHYTHM_ROD_AMOUNT; rod++, i++) {
         if (rod->active) {
             switch (rod->unk0_b4) {
                 case 0:
@@ -476,14 +476,14 @@ void polyrhythm_spawn_rod(u32 lane) {
     struct PolyrhythmRod *rod = gPolyrhythm->rods;
     u32 i;
 
-    for (i = 0; i < ARRAY_COUNT(gPolyrhythm->rods); i++) {
+    for (i = 0; i < POLYRHYTHM_ROD_AMOUNT; i++) {
         if (!rod->active) {
             break;
         }
         rod++;
     }
 
-    if (i >= ARRAY_COUNT(gPolyrhythm->rods)) {
+    if (i >= POLYRHYTHM_ROD_AMOUNT) {
         return;
     }
 

--- a/src/engines/rhythm_tweezers.c
+++ b/src/engines/rhythm_tweezers.c
@@ -117,7 +117,7 @@ void rhythm_tweezers_init_falling_hairs(void) {
     struct RhythmTweezersFallingHair *hair;
     u32 i;
 
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < ARRAY_COUNT(gRhythmTweezers->fallingHairs); i++) {
         hair = &gRhythmTweezers->fallingHairs[i];
         hair->sprite = create_affine_sprite(anim_rhythm_tweezers_falling_hair, 0, 120, 16, 0x4800, 0x100, -0x200, 0, 0, 0x8000, 0);
         affine_sprite_rotate_with_orbit(hair->sprite, TRUE);
@@ -134,7 +134,7 @@ void rhythm_tweezers_update_falling_hairs(void) {
     struct RhythmTweezersFallingHair *hair;
     u32 i = 0;
 
-    for (i; i <= 4; i++) {
+    for (i; i < ARRAY_COUNT(gRhythmTweezers->fallingHairs); i++) {
         hair = &gRhythmTweezers->fallingHairs[i];
         if (hair->fallDistance <= 0xc7ff) {
             hair->fallDistance += hair->fallSpeed += 0x20;

--- a/src/engines/rhythm_tweezers.c
+++ b/src/engines/rhythm_tweezers.c
@@ -117,7 +117,7 @@ void rhythm_tweezers_init_falling_hairs(void) {
     struct RhythmTweezersFallingHair *hair;
     u32 i;
 
-    for (i = 0; i < ARRAY_COUNT(gRhythmTweezers->fallingHairs); i++) {
+    for (i = 0; i < RHYTHM_TWEEZERS_FALLING_HAIR_AMOUNT; i++) {
         hair = &gRhythmTweezers->fallingHairs[i];
         hair->sprite = create_affine_sprite(anim_rhythm_tweezers_falling_hair, 0, 120, 16, 0x4800, 0x100, -0x200, 0, 0, 0x8000, 0);
         affine_sprite_rotate_with_orbit(hair->sprite, TRUE);
@@ -134,7 +134,7 @@ void rhythm_tweezers_update_falling_hairs(void) {
     struct RhythmTweezersFallingHair *hair;
     u32 i = 0;
 
-    for (i; i < ARRAY_COUNT(gRhythmTweezers->fallingHairs); i++) {
+    for (i; i < RHYTHM_TWEEZERS_FALLING_HAIR_AMOUNT; i++) {
         hair = &gRhythmTweezers->fallingHairs[i];
         if (hair->fallDistance <= 0xc7ff) {
             hair->fallDistance += hair->fallSpeed += 0x20;
@@ -163,7 +163,7 @@ void rhythm_tweezers_spawn_falling_hair(u32 arg0) {
     hair->fallSpeed = 0;
     affine_sprite_set_anim_frame(hair->sprite, arg0);
 
-    if (++gRhythmTweezers->fallingHairsNext > (ARRAY_COUNT(gRhythmTweezers->fallingHairs) - 1)) {
+    if (++gRhythmTweezers->fallingHairsNext > (RHYTHM_TWEEZERS_FALLING_HAIR_AMOUNT - 1)) {
         gRhythmTweezers->fallingHairsNext = 0;
     }
 }

--- a/src/engines/rhythm_tweezers.c
+++ b/src/engines/rhythm_tweezers.c
@@ -163,7 +163,7 @@ void rhythm_tweezers_spawn_falling_hair(u32 arg0) {
     hair->fallSpeed = 0;
     affine_sprite_set_anim_frame(hair->sprite, arg0);
 
-    if ((gRhythmTweezers->fallingHairsNext += 1) > 4) {
+    if (++gRhythmTweezers->fallingHairsNext > (ARRAY_COUNT(gRhythmTweezers->fallingHairs) - 1)) {
         gRhythmTweezers->fallingHairsNext = 0;
     }
 }

--- a/src/engines/showtime.c
+++ b/src/engines/showtime.c
@@ -206,7 +206,7 @@ void func_0802c1f0(u32 unused, s16 sprite, u32 arg2) {
 void func_0802c23c() {
     s32 i;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2; i++) { // TODO define
         gShowtime->unk8[i].unk4 = 0;
 
         if (gShowtime->version != SHOWTIME_VER_REMIX_3) {
@@ -230,7 +230,7 @@ void func_0802c23c() {
 void func_0802c334() {
     s32 i;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2; i++) { // TODO define
         if (gShowtime->unk8[i].unk4 == 0) {
             continue;
         }
@@ -341,7 +341,7 @@ void func_0802d38c(void) {
 void func_0802d8bc(u32 arg) {
     s32 i;
 
-    for (i = 0; i < 8; i++) {
+    for (i = 0; i < 8; i++) { // TODO define
         if (gShowtime->unk174[i].unk4 == 0) {
             gShowtime->unk174[i].unk4 = 4;
             gShowtime->unk174[i].unkC = arg;

--- a/src/engines/showtime.c
+++ b/src/engines/showtime.c
@@ -206,7 +206,7 @@ void func_0802c1f0(u32 unused, s16 sprite, u32 arg2) {
 void func_0802c23c() {
     s32 i;
 
-    for (i = 0; i < 2; i++) { // TODO define
+    for (i = 0; i < SHOWTIME_SUB_AMOUNT; i++) {
         gShowtime->unk8[i].unk4 = 0;
 
         if (gShowtime->version != SHOWTIME_VER_REMIX_3) {
@@ -230,7 +230,7 @@ void func_0802c23c() {
 void func_0802c334() {
     s32 i;
 
-    for (i = 0; i < 2; i++) { // TODO define
+    for (i = 0; i < SHOWTIME_SUB_AMOUNT; i++) {
         if (gShowtime->unk8[i].unk4 == 0) {
             continue;
         }
@@ -341,7 +341,7 @@ void func_0802d38c(void) {
 void func_0802d8bc(u32 arg) {
     s32 i;
 
-    for (i = 0; i < 8; i++) { // TODO define
+    for (i = 0; i < SHOWTIME_SUB2_AMOUNT; i++) {
         if (gShowtime->unk174[i].unk4 == 0) {
             gShowtime->unk174[i].unk4 = 4;
             gShowtime->unk174[i].unkC = arg;

--- a/src/engines/sick_beats.c
+++ b/src/engines/sick_beats.c
@@ -125,7 +125,7 @@ void sick_beats_draw_score(u32 type) {
     struct SickBeatsScoreCounter *scoreCounters = &gSickBeats->scoreCounters[type];
     u32 value = scoreCounters->value;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < ARRAY_COUNT(scoreCounters->digitSprite); i++) {
         func_0804cebc(D_03005380, scoreCounters->digitSprite[i], value % 10);
         value /= 10;
     }

--- a/src/engines/sick_beats.c
+++ b/src/engines/sick_beats.c
@@ -24,11 +24,11 @@ void sick_beats_init_particles(void) {
         return;
     }
     gSickBeats->particleSprites[0] = func_0804d160(D_03005380, anim_sick_beats_endless_particle, 0, 64, 64, 0x800, 0, 0, 0x8000);
-    for (i = 1; i < ARRAY_COUNT(gSickBeats->particleSprites); i++) { // Copy particles
+    for (i = 1; i < SICK_BEATS_PARTICLE_AMOUNT; i++) { // Copy particles
         gSickBeats->particleSprites[i] = func_0804d3cc(D_03005380, gSickBeats->particleSprites[0]);
     }
 
-    for (i = 0; i < ARRAY_COUNT(gSickBeats->particleCounters); i++) {
+    for (i = 0; i < SICK_BEATS_PARTICLE_AMOUNT; i++) {
         gSickBeats->particleCounters[i] = 0;
     }
     gSickBeats->particleCurrent = 0;
@@ -43,7 +43,7 @@ void sick_beats_update_particles(void) {
     if ((gSickBeats->version != ENGINE_VER_SICK_BEATS_ENDLESS) || gSickBeats->microbeWasHurt) {
         return;
     }
-    for (i = 0; i < ARRAY_COUNT(gSickBeats->particleCounters); i++) {
+    for (i = 0; i < SICK_BEATS_PARTICLE_AMOUNT; i++) {
         if (gSickBeats->particleCounters[i]) {
             gSickBeats->particleCounters[i] -= 1;
             if (!gSickBeats->particleCounters[i]) {
@@ -159,7 +159,9 @@ void sick_beats_init_virus(void) {
     u32 i;
     struct SickBeatsVirus *virus = &gSickBeats->virus;
 
-    for (i = 0; i < ARRAY_COUNT(virus->exists); i++) virus->exists[i] = FALSE;
+    for (i = 0; i < ARRAY_COUNT(virus->exists); i++) {
+        virus->exists[i] = FALSE;
+    }
     virus->state = SICK_BEATS_VIRUS_STATE_INVALID;
     virus->current = 0;
     virus->spawnedCounter = 0;
@@ -168,7 +170,9 @@ void sick_beats_init_virus(void) {
     virus->hitsRequired = 1;
     virus->virusPalette = 0;
 
-    for (i = 0; i < ARRAY_COUNT(virus->virusData); i++) virus->virusData[i].path = NULL;
+    for (i = 0; i < SICK_BEATS_VIRUS_AMOUNT; i++) {
+        virus->virusData[i].path = NULL;
+    }
 }
 
 // Process Virus Data
@@ -216,7 +220,7 @@ void sick_beats_update_virus(void) {
     i = 0;
     virusData = engineData->virus.virusData;
 
-    for (i; i < ARRAY_COUNT(gSickBeats->virus.virusData); i++) {
+    for (i; i < SICK_BEATS_VIRUS_AMOUNT; i++) {
         sick_beats_process_virus_data(virusData);
         virusData++;
     }
@@ -235,19 +239,12 @@ void sick_beats_spawn_virus(struct SickBeatsPath *path) {
     struct SickBeatsVirusData *virusData;
     u32 i = 0;
     
-    virusData = gSickBeats->virus.virusData;
-    if (virusData->path) {
-        struct SickBeatsVirusData *virusDatatemp = virus->virusData;
-        
-        do {
-            virusDatatemp++;
-            if (++i > ARRAY_COUNT(gSickBeats->virus.virusData)-1) {
-                return;
-            }
-            virusData = virusDatatemp;
-        } while (virusData->path);
+    for (virusData = &virus->virusData[0]; virusData->path != NULL; virusData = &virus->virusData[i]) {
+        if (++i > (SICK_BEATS_VIRUS_AMOUNT - 1)) {
+            return;
+        }
     }
-    if (i > ARRAY_COUNT(gSickBeats->virus.virusData)-1) {
+    if (i > (SICK_BEATS_VIRUS_AMOUNT - 1)) {
         return;
     }
     virusData->path = path;
@@ -544,7 +541,7 @@ struct SickBeatsVirusData *sick_beats_get_virus_data(u32 id) {
     struct SickBeatsVirusData *virusData = gSickBeats->virus.virusData;
     struct SickBeatsVirusData *virusData1 = virus->virusData;
 
-    for (i; (i < ARRAY_COUNT(gSickBeats->virus.virusData)); virusData++, virusData1++, i++) {
+    for (i; (i < SICK_BEATS_VIRUS_AMOUNT); virusData++, virusData1++, i++) {
         if (virusData->path && virusData->virusID == id) {
             return virusData1;
         }

--- a/src/engines/sneaky_spirits.c
+++ b/src/engines/sneaky_spirits.c
@@ -64,7 +64,7 @@ void sneaky_spirits_update_fast_rain(void) {
         func_0804d770(D_03005380, sprite, 1);
 
         gSneakySpirits->rainDropNext += 1;
-        if (gSneakySpirits->rainDropNext >= 30) {
+        if (gSneakySpirits->rainDropNext >= ARRAY_COUNT(gSneakySpirits->rainDrops)) {
             gSneakySpirits->rainDropNext = 0;
         }
     }
@@ -76,7 +76,7 @@ void sneaky_spirits_update_fast_rain(void) {
         func_0804d770(D_03005380, sprite, 1);
 
         gSneakySpirits->rainSplashNext += 1;
-        if (gSneakySpirits->rainSplashNext >= 20) {
+        if (gSneakySpirits->rainSplashNext >= ARRAY_COUNT(gSneakySpirits->rainSplashes)) {
             gSneakySpirits->rainSplashNext = 0;
         }
     }

--- a/src/engines/sneaky_spirits.c
+++ b/src/engines/sneaky_spirits.c
@@ -37,10 +37,10 @@ void sneaky_spirits_show_ghost(u32 position) {
 void sneaky_spirits_init_rain(void) {
     u32 i;
 
-    for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainDrops); i++) {
+    for (i = 0; i < SNEAKY_SPIRITS_RAIN_DROP_AMOUNT; i++) {
         gSneakySpirits->rainDrops[i] = func_0804d160(D_03005380, anim_sneaky_spirits_rain, 0, 120, 80, 0x800, 0, 0, 0x8000);
     }
-    for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainSplashes); i++) {
+    for (i = 0; i < SNEAKY_SPIRITS_RAIN_SPLASH_AMOUNT; i++) {
         gSneakySpirits->rainSplashes[i] = func_0804d160(D_03005380, anim_sneaky_spirits_splash, 0, 64, 64, 0x8400, 0, 0, 0x8002);
     }
 
@@ -64,7 +64,7 @@ void sneaky_spirits_update_fast_rain(void) {
         func_0804d770(D_03005380, sprite, 1);
 
         gSneakySpirits->rainDropNext += 1;
-        if (gSneakySpirits->rainDropNext >= ARRAY_COUNT(gSneakySpirits->rainDrops)) {
+        if (gSneakySpirits->rainDropNext >= SNEAKY_SPIRITS_RAIN_DROP_AMOUNT) {
             gSneakySpirits->rainDropNext = 0;
         }
     }
@@ -76,7 +76,7 @@ void sneaky_spirits_update_fast_rain(void) {
         func_0804d770(D_03005380, sprite, 1);
 
         gSneakySpirits->rainSplashNext += 1;
-        if (gSneakySpirits->rainSplashNext >= ARRAY_COUNT(gSneakySpirits->rainSplashes)) {
+        if (gSneakySpirits->rainSplashNext >= SNEAKY_SPIRITS_RAIN_SPLASH_AMOUNT) {
             gSneakySpirits->rainSplashNext = 0;
         }
     }
@@ -99,7 +99,7 @@ void sneaky_spirits_set_rain_speed(u32 slowMotion) {
     gSneakySpirits->rainSlow = slowMotion;
 
     if (slowMotion) {
-        for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainDrops); i++) {
+        for (i = 0; i < SNEAKY_SPIRITS_RAIN_DROP_AMOUNT; i++) {
             sprite = gSneakySpirits->rainDrops[i];
             animSpeed = (!gSneakySpirits->freezeRain) ? INT_TO_FIXED(1.0) / (agb_random(3) + 1) : 0;
 
@@ -109,7 +109,7 @@ void sneaky_spirits_set_rain_speed(u32 slowMotion) {
             func_0804d770(D_03005380, sprite, 1);
         }
 
-        for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainSplashes); i++) {
+        for (i = 0; i < SNEAKY_SPIRITS_RAIN_SPLASH_AMOUNT; i++) {
             sprite = gSneakySpirits->rainSplashes[i];
             func_0804da20(D_03005380, sprite, 1);
         }
@@ -118,14 +118,14 @@ void sneaky_spirits_set_rain_speed(u32 slowMotion) {
     }
 
     else {
-        for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainDrops); i++) {
+        for (i = 0; i < SNEAKY_SPIRITS_RAIN_DROP_AMOUNT; i++) {
             sprite = gSneakySpirits->rainDrops[i];
 
             func_0804d770(D_03005380, sprite, 0);
             func_0804dcb8(D_03005380, sprite, INT_TO_FIXED(1.0));
         }
 
-        for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainSplashes); i++) {
+        for (i = 0; i < SNEAKY_SPIRITS_RAIN_SPLASH_AMOUNT; i++) {
             sprite = gSneakySpirits->rainSplashes[i];
             func_0804da20(D_03005380, sprite, 0);
         }

--- a/src/engines/sneaky_spirits.c
+++ b/src/engines/sneaky_spirits.c
@@ -37,10 +37,10 @@ void sneaky_spirits_show_ghost(u32 position) {
 void sneaky_spirits_init_rain(void) {
     u32 i;
 
-    for (i = 0; i < 30; i++) {
+    for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainDrops); i++) {
         gSneakySpirits->rainDrops[i] = func_0804d160(D_03005380, anim_sneaky_spirits_rain, 0, 120, 80, 0x800, 0, 0, 0x8000);
     }
-    for (i = 0; i < 20; i++) {
+    for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainSplashes); i++) {
         gSneakySpirits->rainSplashes[i] = func_0804d160(D_03005380, anim_sneaky_spirits_splash, 0, 64, 64, 0x8400, 0, 0, 0x8002);
     }
 
@@ -99,7 +99,7 @@ void sneaky_spirits_set_rain_speed(u32 slowMotion) {
     gSneakySpirits->rainSlow = slowMotion;
 
     if (slowMotion) {
-        for (i = 0; i < 30; i++) {
+        for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainDrops); i++) {
             sprite = gSneakySpirits->rainDrops[i];
             animSpeed = (!gSneakySpirits->freezeRain) ? INT_TO_FIXED(1.0) / (agb_random(3) + 1) : 0;
 
@@ -109,7 +109,7 @@ void sneaky_spirits_set_rain_speed(u32 slowMotion) {
             func_0804d770(D_03005380, sprite, 1);
         }
 
-        for (i = 0; i < 20; i++) {
+        for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainSplashes); i++) {
             sprite = gSneakySpirits->rainSplashes[i];
             func_0804da20(D_03005380, sprite, 1);
         }
@@ -118,14 +118,14 @@ void sneaky_spirits_set_rain_speed(u32 slowMotion) {
     }
 
     else {
-        for (i = 0; i < 30; i++) {
+        for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainDrops); i++) {
             sprite = gSneakySpirits->rainDrops[i];
 
             func_0804d770(D_03005380, sprite, 0);
             func_0804dcb8(D_03005380, sprite, INT_TO_FIXED(1.0));
         }
 
-        for (i = 0; i < 20; i++) {
+        for (i = 0; i < ARRAY_COUNT(gSneakySpirits->rainSplashes); i++) {
             sprite = gSneakySpirits->rainSplashes[i];
             func_0804da20(D_03005380, sprite, 0);
         }

--- a/src/engines/spaceball.c
+++ b/src/engines/spaceball.c
@@ -38,7 +38,7 @@ void spaceball_update_stars_x_y(void) {
     s32 scale, x, y;
     u32 i;
 
-    for (i = 0; i < 24; i++) {
+    for (i = 0; i < ARRAY_COUNT(gSpaceball->stars); i++) {
         sprite = gSpaceball->starSprite[i];
         star = &gSpaceball->stars[i];
 
@@ -57,7 +57,7 @@ void spaceball_update_stars_z(void) {
     s32 zMax = gSpaceball->zoom + INT_TO_FIXED(4);
     u32 i;
 
-    for (i = 0; i < 24; i++) {
+    for (i = 0; i < ARRAY_COUNT(gSpaceball->stars); i++) {
         star = &gSpaceball->stars[i];
         star->z -= 8;
         if ((star->z < zMin) || (star->z > zMax)) {

--- a/src/engines/spaceball.c
+++ b/src/engines/spaceball.c
@@ -38,7 +38,7 @@ void spaceball_update_stars_x_y(void) {
     s32 scale, x, y;
     u32 i;
 
-    for (i = 0; i < ARRAY_COUNT(gSpaceball->stars); i++) {
+    for (i = 0; i < SPACEBALL_STAR_AMOUNT; i++) {
         sprite = gSpaceball->starSprite[i];
         star = &gSpaceball->stars[i];
 
@@ -57,7 +57,7 @@ void spaceball_update_stars_z(void) {
     s32 zMax = gSpaceball->zoom + INT_TO_FIXED(4);
     u32 i;
 
-    for (i = 0; i < ARRAY_COUNT(gSpaceball->stars); i++) {
+    for (i = 0; i < SPACEBALL_STAR_AMOUNT; i++) {
         star = &gSpaceball->stars[i];
         star->z -= 8;
         if ((star->z < zMin) || (star->z > zMax)) {
@@ -133,7 +133,7 @@ void spaceball_update_graphics(void) {
     func_08008910(BG_LAYER_2, INT_TO_FIXED(128), INT_TO_FIXED(176), h, v, 0);
 
     // Update Stars
-    if (gSpaceball->currentStar < ARRAY_COUNT(gSpaceball->stars)) {
+    if (gSpaceball->currentStar < SPACEBALL_STAR_AMOUNT) {
         gSpaceball->starSprite[gSpaceball->currentStar] = func_0804d160(D_03005380, anim_spaceball_bg_star, 0, 0, 0, 0xc800, 1, 0, 0);
         spaceball_reset_star(gSpaceball->currentStar);
         gSpaceball->currentStar++;

--- a/src/engines/spaceball.c
+++ b/src/engines/spaceball.c
@@ -133,7 +133,7 @@ void spaceball_update_graphics(void) {
     func_08008910(BG_LAYER_2, INT_TO_FIXED(128), INT_TO_FIXED(176), h, v, 0);
 
     // Update Stars
-    if (gSpaceball->currentStar < 24) {
+    if (gSpaceball->currentStar < ARRAY_COUNT(gSpaceball->stars)) {
         gSpaceball->starSprite[gSpaceball->currentStar] = func_0804d160(D_03005380, anim_spaceball_bg_star, 0, 0, 0, 0xc800, 1, 0, 0);
         spaceball_reset_star(gSpaceball->currentStar);
         gSpaceball->currentStar++;

--- a/src/engines/wizards_waltz.c
+++ b/src/engines/wizards_waltz.c
@@ -161,7 +161,7 @@ void wizards_waltz_engine_update(void) {
     if ((gWizardsWaltz->cyclePosition & 7) == 0) {
         gWizardsWaltz->sparkle[gWizardsWaltz->currentSparkle].state = SPARKLE_STATE_QUEUED;
         gWizardsWaltz->currentSparkle++;
-        if (gWizardsWaltz->currentSparkle > 9) {
+        if (gWizardsWaltz->currentSparkle > (ARRAY_COUNT(gWizardsWaltz->sparkle) - 1)) {
             gWizardsWaltz->currentSparkle = 0;
         }
     }

--- a/src/engines/wizards_waltz.c
+++ b/src/engines/wizards_waltz.c
@@ -81,7 +81,7 @@ void wizards_waltz_engine_start(u32 version) {
     gWizardsWaltz->girl.sprite = create_affine_sprite(anim_wizards_waltz_girl_idle, 0, 120, 80, 0x4040, INT_TO_FIXED(0.5), 0, 1, 0, 0, 1);
 
     // Create sparkles.
-    for (i = 0; i < ARRAY_COUNT(gWizardsWaltz->sparkle); i++) {
+    for (i = 0; i < WIZARDS_WALTZ_SPARKLE_AMOUNT; i++) {
         struct AffineSprite *sprite;
         gWizardsWaltz->sparkle[i].state = SPARKLE_STATE_HIDDEN;
         sprite = create_affine_sprite(anim_wizard_sparkle, 0, 0, 0, 0, INT_TO_FIXED(0.5), 0, 1, 0, 0, 0);
@@ -161,13 +161,13 @@ void wizards_waltz_engine_update(void) {
     if ((gWizardsWaltz->cyclePosition & 7) == 0) {
         gWizardsWaltz->sparkle[gWizardsWaltz->currentSparkle].state = SPARKLE_STATE_QUEUED;
         gWizardsWaltz->currentSparkle++;
-        if (gWizardsWaltz->currentSparkle > (ARRAY_COUNT(gWizardsWaltz->sparkle) - 1)) {
+        if (gWizardsWaltz->currentSparkle > (WIZARDS_WALTZ_SPARKLE_AMOUNT - 1)) {
             gWizardsWaltz->currentSparkle = 0;
         }
     }
 
     // Update sparkles (continued).
-    for (i = 0; i < ARRAY_COUNT(gWizardsWaltz->sparkle); i++) {
+    for (i = 0; i < WIZARDS_WALTZ_SPARKLE_AMOUNT; i++) {
         if (gWizardsWaltz->sparkle[i].state != SPARKLE_STATE_HIDDEN) {
             if (gWizardsWaltz->sparkle[i].state == SPARKLE_STATE_QUEUED) {
                 gWizardsWaltz->sparkle[i].rotation = gWizardsWaltz->wizard.rotation - 0x200;

--- a/src/engines/wizards_waltz.c
+++ b/src/engines/wizards_waltz.c
@@ -81,7 +81,7 @@ void wizards_waltz_engine_start(u32 version) {
     gWizardsWaltz->girl.sprite = create_affine_sprite(anim_wizards_waltz_girl_idle, 0, 120, 80, 0x4040, INT_TO_FIXED(0.5), 0, 1, 0, 0, 1);
 
     // Create sparkles.
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(gWizardsWaltz->sparkle); i++) {
         struct AffineSprite *sprite;
         gWizardsWaltz->sparkle[i].state = SPARKLE_STATE_HIDDEN;
         sprite = create_affine_sprite(anim_wizard_sparkle, 0, 0, 0, 0, INT_TO_FIXED(0.5), 0, 1, 0, 0, 0);
@@ -167,7 +167,7 @@ void wizards_waltz_engine_update(void) {
     }
 
     // Update sparkles (continued).
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(gWizardsWaltz->sparkle); i++) {
         if (gWizardsWaltz->sparkle[i].state != SPARKLE_STATE_HIDDEN) {
             if (gWizardsWaltz->sparkle[i].state == SPARKLE_STATE_QUEUED) {
                 gWizardsWaltz->sparkle[i].rotation = gWizardsWaltz->wizard.rotation - 0x200;

--- a/src/main.c
+++ b/src/main.c
@@ -200,7 +200,7 @@ void func_08000584(struct Scene *arg1) {
 
 void func_08000598(void) {
 	u32 i;
-	for (i = 0; i < 10; i++) {
+	for (i = 0; i < ARRAY_COUNT(D_03000008); i++) {
 		D_03000008[i].unk0 = NULL;
 		D_03000008[i].unk4 = NULL;
 		D_03000008[i].unk8 = NULL;
@@ -209,7 +209,7 @@ void func_08000598(void) {
 
 struct SceneUnk03000008 *func_080005b8(struct Scene *arg1) {
 	u32 i;
-	for (i = 0; i < 10; i++) {
+	for (i = 0; i < ARRAY_COUNT(D_03000008); i++) {
 		if (D_03000008[i].unk0 == arg1) {
 			return &D_03000008[i];
 		}
@@ -246,7 +246,7 @@ struct SceneUnk03000008 *func_08000630(struct Scene *arg1) {
 	if (arg1 == NULL) {
 		return NULL;
 	}
-	for (i = 0; i < 10; i++) {
+	for (i = 0; i < ARRAY_COUNT(D_03000008); i++) {
 		if (D_03000008[i].unk0 == NULL) {
 			D_03000008[i].unk0 = arg1;
 			D_03000008[i].unk4 = NULL;
@@ -260,7 +260,7 @@ struct SceneUnk03000008 *func_08000630(struct Scene *arg1) {
 void func_08000674(struct Scene *arg1) {
 	if (arg1 != NULL) {
 		u32 i;
-		for (i = 0; i < 10; i++) {
+		for (i = 0; i < ARRAY_COUNT(D_03000008); i++) {
 			if (D_03000008[i].unk0 == arg1) {
 				D_03000008[i].unk0 = NULL;
 				D_03000008[i].unk4 = NULL;

--- a/src/scenes/cafe.h
+++ b/src/scenes/cafe.h
@@ -3,14 +3,14 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+#define END_OF_DIALOGUE NULL
+
+
 // Scene Types:
 struct CafeSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
-#define END_OF_DIALOGUE NULL
 
 
 // Scene Data:

--- a/src/scenes/data_check.h
+++ b/src/scenes/data_check.h
@@ -4,13 +4,13 @@
 #include "scenes.h"
 #include "src/memory.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct DataCheckSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/data_room.h
+++ b/src/scenes/data_room.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct DataRoomSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/debug_asset_test.h
+++ b/src/scenes/debug_asset_test.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct AssetTestSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/debug_data_clear.h
+++ b/src/scenes/debug_data_clear.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct DataClearSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/debug_empty_test.h
+++ b/src/scenes/debug_empty_test.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct EmptyTestSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/debug_flash_mem.h
+++ b/src/scenes/debug_flash_mem.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct FlashMemoryTestSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/debug_menu.h
+++ b/src/scenes/debug_menu.h
@@ -3,6 +3,10 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+#define END_OF_DEBUG_ENTRIES { NULL, NULL }
+
+
 // Scene Types:
 struct DebugMenuSceneData {
     /* add fields here */
@@ -12,11 +16,6 @@ struct DebugMenuEntry {
     struct Scene *scene;
     const char *label;
 };
-
-#define END_OF_DEBUG_ENTRIES { NULL, NULL }
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/epilogue.h
+++ b/src/scenes/epilogue.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct EpilogueSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/game_select.c
+++ b/src/scenes/game_select.c
@@ -589,7 +589,7 @@ void save_level_state_from_grid_xy(s32 x, s32 y, s32 state) {
 void game_select_init_color_mod(void) {
     u32 i;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < ARRAY_COUNT(gGameSelect->colorChangers); i++) {
         struct ColorChanger *changer = &gGameSelect->colorChangers[i];
 
         changer->r1 = changer->g1 = changer->b1 = 31;
@@ -2116,7 +2116,7 @@ void game_select_init_flow_pane(void) {
     u32 updateFlow;
     u32 i;
 
-    for (i = 0; i < 3; i++) {
+    for (i = 0; i < ARRAY_COUNT(flowPane->digits); i++) {
         flowPane->digits[i] = func_0804d160(D_03005380, anim_game_select_flow_num, 10, 208 - (i * 8), 128, 0, 0, 0, 0);
         func_0804db44(D_03005380, flowPane->digits[i], &bgOfs->x, &bgOfs->y);
     }
@@ -2131,7 +2131,7 @@ void game_select_init_flow_pane(void) {
     initialScore = flowPane->previousScore;
 
     if (initialScore > 0) {
-        for (i = 0; i < 3; i++) {
+        for (i = 0; i < ARRAY_COUNT(flowPane->digits); i++) {
             func_0804cebc(D_03005380, flowPane->digits[i], ((initialScore != 0) ? (initialScore % 10) : 10));
             initialScore /= 10;
         }
@@ -2177,7 +2177,7 @@ void game_select_update_flow_pane(void) {
                 func_0804cebc(D_03005380, flowPane->title, 0);
                 flow = flowPane->currentScore;
 
-                for (i = 0; i < 3; i++) {
+                for (i = 0; i < ARRAY_COUNT(flowPane->digits); i++) {
                     func_0804cebc(D_03005380, flowPane->digits[i], ((flow != 0) ? (flow % 10) : 10));
                     flow /= 10;
                 }
@@ -2213,14 +2213,14 @@ void game_select_update_flow_pane(void) {
                     func_0804d770(D_03005380, flowPane->arrow, TRUE);
                 }
 
-                for (i = 0; i < 3; i++) {
+                for (i = 0; i < ARRAY_COUNT(flowPane->digits); i++) {
                     func_0804d770(D_03005380, flowPane->digits[i], TRUE);
                 }
             } else {
                 render = (flowPane->timer >> 4) & 1;
                 render ^= 1;
 
-                for (i = 0; i < 3; i++) {
+                for (i = 0; i < ARRAY_COUNT(flowPane->digits); i++) {
                     func_0804d770(D_03005380, flowPane->digits[i], render);
                 }
 
@@ -2505,7 +2505,7 @@ void game_select_init_squares(void) {
     x *= 2;
     y *= 2;
 
-    for (i = 16; i < 50; i++) {
+    for (i = 16; i < ARRAY_COUNT(gGameSelect->squareVectors); i++) {
         vector = &gGameSelect->squareVectors[i];
         vector->x = agb_random(x);
         vector->y = agb_random(y);
@@ -2516,7 +2516,7 @@ void game_select_init_squares(void) {
     D_03004b10.BLDMOD = (BLDMOD_BG0_TGT | BLDMOD_BG1_TGT | BLDMOD_BG2_TGT | BLDMOD_BG3_TGT | BLDMOD_BACKDROP_TGT);
     D_03004b10.COLEV = (COLEV_SRC_PIXEL(16) | COLEV_TGT_PIXEL(16));
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(gGameSelect->newIconSquares); i++) {
         gGameSelect->newIconSquares[i].active = FALSE;
     }
 }
@@ -2565,7 +2565,7 @@ void game_select_update_bg_squares_motion(s32 dx, s32 dy) {
     y2 = y * 2;
 
     // Small Squares
-    for (i = 16; i < 50; i++) {
+    for (i = 16; i < ARRAY_COUNT(gGameSelect->squareVectors); i++) {
         vector = &gGameSelect->squareVectors[i];
         vector->x += dx;
         vector->y += dy;
@@ -2598,14 +2598,14 @@ void game_select_spawn_icon_square(s16 x, s16 y, void *onFinish, s32 onFinishArg
     s32 x1, y1, x2, y2;
     u32 i;
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(gGameSelect->newIconSquares); i++) {
         if (!shadow->active) {
             break;
         }
         shadow++;
     }
 
-    if (i >= 10) {
+    if (i >= ARRAY_COUNT(gGameSelect->newIconSquares)) {
         return;
     }
 
@@ -2674,7 +2674,7 @@ void game_select_update_icon_square(struct NewIconSquare *shadow) {
 void game_select_update_icon_squares(void) {
     u32 i;
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(gGameSelect->newIconSquares); i++) {
         game_select_update_icon_square(&gGameSelect->newIconSquares[i]);
     }
 }
@@ -2685,7 +2685,7 @@ u32 game_select_check_for_icon_squares(void) {
     struct NewIconSquare *shadow = gGameSelect->newIconSquares;
     u32 i;
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < ARRAY_COUNT(gGameSelect->newIconSquares); i++) {
         if (shadow->active) {
             return TRUE;
         }

--- a/src/scenes/game_select.c
+++ b/src/scenes/game_select.c
@@ -2,7 +2,6 @@
 #include "game_select.h"
 #include "graphics/game_select/game_select_graphics.h"
 
-#include "levels.h"
 #include "src/memory.h"
 #include "src/code_08001360.h"
 #include "src/bitmap_font.h"

--- a/src/scenes/game_select.c
+++ b/src/scenes/game_select.c
@@ -1302,7 +1302,7 @@ void game_select_enqueue_level_event(s32 x, s32 y, s32 state) {
         data->state = state;
 
         gGameSelect->totalLevelEventsQueued++;
-        if (++gGameSelect->levelEventEnqueueID >= 16) {
+        if (++gGameSelect->levelEventEnqueueID >= ARRAY_COUNT(gGameSelect->levelEventsQueue)) {
             gGameSelect->levelEventEnqueueID = 0;
         }
     }
@@ -1324,7 +1324,7 @@ void game_select_dequeue_level_event(s32 *xReq, s32 *yReq, s32 *stateReq) {
     *stateReq = data->state;
 
     gGameSelect->totalLevelEventsQueued--;
-    if (++gGameSelect->levelEventDequeueID >= 16) {
+    if (++gGameSelect->levelEventDequeueID >= ARRAY_COUNT(gGameSelect->levelEventsQueue)) {
         gGameSelect->levelEventDequeueID = 0;
     }
 }

--- a/src/scenes/game_select.h
+++ b/src/scenes/game_select.h
@@ -2,6 +2,41 @@
 
 #include "global.h"
 #include "scenes.h"
+#include "levels.h"
+
+// Scene Macros/Enums:
+enum CampaignBordersEnum {
+    /* 00 */ CAMPAIGN_BORDER_0_FLOWERS,
+    /* 01 */ CAMPAIGN_BORDER_3_FLOWERS,
+    /* 02 */ CAMPAIGN_BORDER_6_FLOWERS
+};
+
+#define MAX_PERFECT_ATTEMPTS 3
+
+#define GS_GRID_WIDTH 15u
+#define GS_GRID_HEIGHT 12u
+
+#define LEVEL_EVENT_TARGET_ON_SHOW   (1 << 0)
+#define LEVEL_EVENT_MOVE_CURSOR      (1 << 1)
+#define LEVEL_EVENT_CLEAR_BY_DEFAULT (1 << 2)
+#define LEVEL_EVENT_DELAY_CLEAR      (1 << 3)
+#define LEVEL_EVENT_DELAY_OPEN       (1 << 4)
+#define LEVEL_EVENT_DELAY_SHOW       (1 << 5)
+#define LEVEL_EVENT_TARGET_ON_OPEN   (1 << 6)
+
+#define LEVEL_ICON_ANIM_STOP -2
+#define LEVEL_ICON_ANIM_LOOP -1
+
+enum LevelIconOverlaysEnum {
+    /* 00 */ LEVEL_ICON_OVERLAY_BLANK,
+    /* 01 */ LEVEL_ICON_OVERLAY_CLOSED,
+    /* 02 */ LEVEL_ICON_OVERLAY_UNCLEARED,
+    /* 03 */ LEVEL_ICON_OVERLAY_CLEARED,
+    /* 04 */ LEVEL_ICON_OVERLAY_MEDAL,
+    /* 05 */ LEVEL_ICON_OVERLAY_REMIX_CLOSED,
+    /* 06 */ LEVEL_ICON_OVERLAY_REMIX_UNCLEARED,
+    /* 07 */ LEVEL_ICON_OVERLAY_BONUS
+};
 
 
 // Scene Types:
@@ -116,7 +151,7 @@ struct GameSelectSceneData {
         char text[0x100];
         u8 unused452;
         u8 totalAvailable;
-        u8 indexes[48];
+        u8 indexes[TOTAL_RHYTHM_GAMES];
     } campaignNotice;
     u8 unused484[100];
 
@@ -180,41 +215,6 @@ struct LevelIconAnimatorTask {
     u16 size;
     u8 currentFrame;
     u8 timeUntilNext;
-};
-
-
-// Scene Macros/Enums:
-enum CampaignBordersEnum {
-    /* 00 */ CAMPAIGN_BORDER_0_FLOWERS,
-    /* 01 */ CAMPAIGN_BORDER_3_FLOWERS,
-    /* 02 */ CAMPAIGN_BORDER_6_FLOWERS
-};
-
-#define MAX_PERFECT_ATTEMPTS 3
-
-#define GS_GRID_WIDTH 15u
-#define GS_GRID_HEIGHT 12u
-
-#define LEVEL_EVENT_TARGET_ON_SHOW   (1 << 0)
-#define LEVEL_EVENT_MOVE_CURSOR      (1 << 1)
-#define LEVEL_EVENT_CLEAR_BY_DEFAULT (1 << 2)
-#define LEVEL_EVENT_DELAY_CLEAR      (1 << 3)
-#define LEVEL_EVENT_DELAY_OPEN       (1 << 4)
-#define LEVEL_EVENT_DELAY_SHOW       (1 << 5)
-#define LEVEL_EVENT_TARGET_ON_OPEN   (1 << 6)
-
-#define LEVEL_ICON_ANIM_STOP -2
-#define LEVEL_ICON_ANIM_LOOP -1
-
-enum LevelIconOverlaysEnum {
-    /* 00 */ LEVEL_ICON_OVERLAY_BLANK,
-    /* 01 */ LEVEL_ICON_OVERLAY_CLOSED,
-    /* 02 */ LEVEL_ICON_OVERLAY_UNCLEARED,
-    /* 03 */ LEVEL_ICON_OVERLAY_CLEARED,
-    /* 04 */ LEVEL_ICON_OVERLAY_MEDAL,
-    /* 05 */ LEVEL_ICON_OVERLAY_REMIX_CLOSED,
-    /* 06 */ LEVEL_ICON_OVERLAY_REMIX_UNCLEARED,
-    /* 07 */ LEVEL_ICON_OVERLAY_BONUS
 };
 
 

--- a/src/scenes/gameplay.c
+++ b/src/scenes/gameplay.c
@@ -478,7 +478,7 @@ void gameplay_set_miss_punishment_duration(u32 duration) {
 
 // [func_08017758] Set Inter-Engine Variable
 void gameplay_set_inter_engine_variable(u32 i, s32 val) {
-    if (i >= 64) {
+    if (i >= ARRAY_COUNT(gGameplay->interEngineVariableSpace)) {
         return;
     }
 
@@ -488,7 +488,7 @@ void gameplay_set_inter_engine_variable(u32 i, s32 val) {
 
 // [func_0801777c] Get Inter-Engine Variable
 s32 gameplay_get_inter_engine_variable(u32 i) {
-    if (i >= 64) {
+    if (i >= ARRAY_COUNT(gGameplay->interEngineVariableSpace)) {
         return 0;
     }
 

--- a/src/scenes/gameplay.h
+++ b/src/scenes/gameplay.h
@@ -6,6 +6,9 @@
 #include "src/main.h"
 #include "riq_main_scene.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct GameplaySceneData {
 	s32 unk0;
@@ -70,9 +73,6 @@ struct GameplaySceneData {
     u8  mercyEnabled;
     u8  forgivableMisses;
 };
-
-
-// Scene Macros/Enums:
 
 
 // Sound Effects:

--- a/src/scenes/library.h
+++ b/src/scenes/library.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct LibrarySceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/main_menu.c
+++ b/src/scenes/main_menu.c
@@ -88,7 +88,7 @@ void main_menu_scene_start(void *sceneVar, s32 dataArg) {
     main_menu_scene_init_gfx1();
     func_0804d160(D_03005380, anim_main_menu_blank1, 0, 120, 64, 0x6E, 1, 0, 0);
 
-    for (i = 0; i < 5; i++) {
+    for (i = 0; i < ARRAY_COUNT(gMainMenu->buttons); i++) {
         if (i == sMainMenuButton) {
             gMainMenu->buttons[i] = func_0804d160(D_03005380, main_menu_button_on_anim[i], 0, 120, 64, 0x64, 1, 0, 0);
         } else {

--- a/src/scenes/main_menu.c
+++ b/src/scenes/main_menu.c
@@ -88,7 +88,7 @@ void main_menu_scene_start(void *sceneVar, s32 dataArg) {
     main_menu_scene_init_gfx1();
     func_0804d160(D_03005380, anim_main_menu_blank1, 0, 120, 64, 0x6E, 1, 0, 0);
 
-    for (i = 0; i < ARRAY_COUNT(gMainMenu->buttons); i++) {
+    for (i = 0; i < TOTAL_MAIN_MENU_BUTTONS; i++) {
         if (i == sMainMenuButton) {
             gMainMenu->buttons[i] = func_0804d160(D_03005380, main_menu_button_on_anim[i], 0, 120, 64, 0x64, 1, 0, 0);
         } else {

--- a/src/scenes/main_menu.h
+++ b/src/scenes/main_menu.h
@@ -3,21 +3,21 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+#define TOTAL_MAIN_MENU_BUTTONS 5
+
+
 // Scene Types:
 struct MainMenuSceneData {
     struct BitmapFontBG *bmpFontBG;
     struct BitmapFontOBJ *bmpFontOBJ;
     u32 scriptIsReady; // Set to FALSE during screen fade-in/out.
-    s16 buttons[5];
+    s16 buttons[TOTAL_MAIN_MENU_BUTTONS];
     s16 bgX;
     s16 bgY;
     u8 unk1A;
     u8 loadingOptionsMenu;
 };
-
-
-// Scene Macros/Enums:
-#define TOTAL_MAIN_MENU_BUTTONS 5
 
 
 // Scene Data:

--- a/src/scenes/medal_corner.h
+++ b/src/scenes/medal_corner.h
@@ -3,26 +3,6 @@
 #include "global.h"
 #include "scenes.h"
 
-// Scene Types:
-struct MedalCornerSceneData {
-    /* add fields here */
-};
-
-struct MedalCornerLevel {
-    struct Scene *scene;
-    const char *title;
-    struct Animation *icon;
-    u8 medalsToUnlock;
-};
-
-struct MedalCornerMenu {
-    u8 levelCount;
-    struct SequenceData *bgm;
-    struct GraphicsTable *gfx;
-    struct MedalCornerLevel *levels;
-};
-
-
 // Scene Macros/Enums:
 enum RhythmToysEnum {
     RHYTHM_TOY_CAT_MACHINE,
@@ -64,6 +44,26 @@ enum DrumLessonsEnum {
     DRUM_LESSON_HI_TECH_2,
 
     TOTAL_DRUM_LESSONS
+};
+
+
+// Scene Types:
+struct MedalCornerSceneData {
+    /* add fields here */
+};
+
+struct MedalCornerLevel {
+    struct Scene *scene;
+    const char *title;
+    struct Animation *icon;
+    u8 medalsToUnlock;
+};
+
+struct MedalCornerMenu {
+    u8 levelCount;
+    struct SequenceData *bgm;
+    struct GraphicsTable *gfx;
+    struct MedalCornerLevel *levels;
 };
 
 

--- a/src/scenes/options.h
+++ b/src/scenes/options.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct OptionsSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/perfect.h
+++ b/src/scenes/perfect.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct PerfectSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/reading.h
+++ b/src/scenes/reading.h
@@ -3,19 +3,6 @@
 #include "global.h"
 #include "scenes.h"
 
-// Scene Types:
-struct ReadingSceneData {
-    /* add fields here */
-};
-
-struct ReadingMaterial {
-    const char *title;
-    const char *text;
-    const struct GraphicsTable *gfx;
-    struct SequenceData **bgm;
-};
-
-
 // Scene Macros/Enums:
 enum ReadingMaterialEnum {
     /* 00 */ READING_MATERIAL_WELCOME,
@@ -38,6 +25,19 @@ enum ReadingMaterialEnum {
     /* 17 */ READING_MATERIAL_RHYTHM_DIAGNOSIS,
     /* 18 */ READING_MATERIAL_RHYTHM_POEM,
     /* 19 */ READING_MATERIAL_RHYTHM_HAIKU
+};
+
+
+// Scene Types:
+struct ReadingSceneData {
+    /* add fields here */
+};
+
+struct ReadingMaterial {
+    const char *title;
+    const char *text;
+    const struct GraphicsTable *gfx;
+    struct SequenceData **bgm;
 };
 
 
@@ -71,13 +71,13 @@ extern struct ReadingMaterial reading_material_error;
 // extern ? func_0801a8b0(?); // ? (Script Function)
 
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct ReadErrorSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/results.c
+++ b/src/scenes/results.c
@@ -315,7 +315,7 @@ void results_init_cue_tracking(void) {
 
     D_089d7980->markingData = NULL;
 
-    for (i = 0; i < 16; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_089d7980->cueInputTrackers); i++) {
         results_init_tracker(&D_089d7980->cueInputTrackers[i]);
     }
 }
@@ -330,7 +330,7 @@ void results_init_score_handler(void) {
     D_089d7980->prevInputLevel = -1;
     D_089d7980->totalIrrelevantInputs = 0;
 
-    for (i = 0; i < 4; i++) {
+    for (i = 0; i < ARRAY_COUNT(D_089d7980->anyInputTrackers); i++) {
         results_init_tracker(&D_089d7980->anyInputTrackers[i]);
     }
 

--- a/src/scenes/results.h
+++ b/src/scenes/results.h
@@ -3,6 +3,22 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+enum ResultsRanksEnum {
+    RESULTS_RANK_TRY_AGAIN,
+    RESULTS_RANK_OK,
+    RESULTS_RANK_SUPERB
+};
+
+enum ResultsLevelIconsEnum {
+    RESULT_ICON_OK,
+    RESULT_ICON_TRY_AGAIN,
+    RESULT_ICON_SUPERB
+};
+
+#define END_OF_RESULTS_TEXT_EVENT_LIST { 0, NULL, NULL }
+
+
 // Scene Types:
 struct ResultsSceneData {
     struct BitmapFontBG *bgFont;
@@ -68,22 +84,6 @@ struct ResultsTextEvent {
     u8 unk0;
     const char **textPool;
     u32 (*func)(void);
-};
-
-#define END_OF_RESULTS_TEXT_EVENT_LIST { 0, NULL, NULL }
-
-
-// Scene Macros/Enums:
-enum ResultsRanksEnum {
-    RESULTS_RANK_TRY_AGAIN,
-    RESULTS_RANK_OK,
-    RESULTS_RANK_SUPERB
-};
-
-enum ResultsLevelIconsEnum {
-    RESULT_ICON_OK,
-    RESULT_ICON_TRY_AGAIN,
-    RESULT_ICON_SUPERB
 };
 
 

--- a/src/scenes/studio.h
+++ b/src/scenes/studio.h
@@ -3,18 +3,6 @@
 #include "global.h"
 #include "scenes.h"
 
-// Scene Types:
-struct StudioSceneData {
-    /* add fields here */
-};
-
-struct StudioEntry {
-    const char *fullTitle;
-    const char *shortTitle;
-    const struct Beatscript *script;
-};
-
-
 // Scene Macros/Enums:
 enum StudioSongsEnum {
     /* 00 */ STUDIO_SONG_SILENCE,
@@ -80,6 +68,18 @@ enum StudioDrumKitsEnum {
     /* 12 */ STUDIO_DRUM_TAP,
     /* 13 */ STUDIO_DRUM_AIR,
     /* 14 */ STUDIO_DRUM_SAMURAI
+};
+
+
+// Scene Types:
+struct StudioSceneData {
+    /* add fields here */
+};
+
+struct StudioEntry {
+    const char *fullTitle;
+    const char *shortTitle;
+    const struct Beatscript *script;
 };
 
 

--- a/src/scenes/title.h
+++ b/src/scenes/title.h
@@ -3,6 +3,9 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct TitleSceneData {
     /* add fields here */
@@ -13,9 +16,6 @@ struct TitleLogoCharData {
     s16 x, y;
     s16 unk8;
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:

--- a/src/scenes/warning.h
+++ b/src/scenes/warning.h
@@ -3,13 +3,13 @@
 #include "global.h"
 #include "scenes.h"
 
+// Scene Macros/Enums:
+
+
 // Scene Types:
 struct WarningSceneData {
     /* add fields here */
 };
-
-
-// Scene Macros/Enums:
 
 
 // Scene Data:


### PR DESCRIPTION
Also:

- Move the engine/scene macros/defines to the top of their respective files (makes it easier to use the macro/enum values in e.g. engine/scene types)
- Clean up the match in `func_0800dfc4`
- Clean up the loop in `sick_beats_spawn_virus`

Right now defines are primarily used in engine/scene code because that would make it easier to change some things modders could be interested in (after we get shiftability maybe) + in Showtime, `ARRAY_COUNT` didn't match (see `func_0802c23c`; `func_0802c334`; `func_0802d8bc`). `ARRAY_COUNT` is used for any "technical" values (i.e. amount of squares in the Game Select scene or `DrumTechController::soundTimers` in `include/engines/night_walk.h`)